### PR TITLE
feat(ui): redesign frontend with OpenAI/ChatGPT style

### DIFF
--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -1,11 +1,14 @@
 <template>
   <div id="app-layout">
     <!-- 移动端遮罩层 -->
-    <div 
-      v-if="isMobile && sidebarVisible" 
-      class="mobile-overlay"
-      @click="sidebarVisible = false"
-    ></div>
+    <Transition name="fade">
+      <div 
+        v-if="isMobile && sidebarVisible" 
+        class="mobile-overlay"
+        style="position:fixed;inset:0;z-index:1000;"
+        @click="sidebarVisible = false"
+      ></div>
+    </Transition>
 
     <!-- 移动端头部 -->
     <header v-if="isMobile" class="mobile-header">
@@ -168,7 +171,6 @@ const handleResize = () => {
 </script>
 
 <style>
-/* 全局样式重置和基础设置 */
 html, body {
   margin: 0;
   padding: 0;
@@ -177,181 +179,154 @@ html, body {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   background-color: var(--apple-bg-color-secondary);
   color: var(--apple-text-color-primary);
-  overflow: hidden; /* 防止整体页面滚动 */
+  overflow: hidden;
 }
 </style>
 
 <style scoped>
-
-/* 新的根布局 */
+/* Root layout - OpenAI style two-panel */
 #app-layout {
   display: flex;
   height: 100vh;
   width: 100vw;
   overflow: hidden;
   position: relative;
-  margin: 0;
-  padding: 0;
   background-color: var(--apple-bg-color-secondary);
 }
 
+/* Main content area - clean, no card styling */
 .main-content {
   flex-grow: 1;
   height: 100vh;
   overflow-y: auto;
-  padding: 20px;
-  box-sizing: border-box;
-  min-width: 0; /* 防止flex item溢出 */
-  margin: 0; /* 确保没有外边距 */
-  background-color: var(--apple-bg-color);
-  border-radius: var(--apple-border-radius-large);
-  box-shadow: var(--apple-shadow-medium);
   overflow-x: hidden;
-}
-
-.main-content-inner {
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-.welcome-view, .editor-view {
-  height: 100%;
+  min-width: 0;
   background-color: var(--apple-bg-color);
-  border-radius: var(--apple-border-radius-large);
-  box-shadow: var(--apple-shadow-medium);
-  padding: 0; /* 移除padding，让内部容器控制 */
   display: flex;
   flex-direction: column;
 }
 
+.welcome-view,
+.editor-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .editor-view-inner {
   flex: 1;
-  padding: 20px;
+  padding: 24px 32px;
   box-sizing: border-box;
   overflow-y: auto;
   overflow-x: hidden;
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
 }
 
-/* no-character-book and no-content styles removed: handled inside CharacterBookEditor */
-
-/* 移动端头部 */
+/* Mobile header */
 .mobile-header {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  height: 60px;
-  background-color: var(--el-bg-color);
-  border-bottom: 1px solid var(--el-border-color-light);
+  height: 56px;
+  background-color: var(--apple-bg-color);
+  border-bottom: 1px solid var(--apple-border-color);
   display: flex;
   align-items: center;
   padding: 0 16px;
   z-index: 1000;
   box-sizing: border-box;
+  gap: 12px;
 }
 
 .mobile-menu-btn {
-  margin-right: 16px;
+  flex-shrink: 0;
 }
 
 .mobile-title {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-size: 18px;
+  gap: 8px;
+  font-size: 15px;
   font-weight: 600;
+  color: var(--apple-text-color-primary);
   flex-grow: 1;
 }
 
 .mobile-logo {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 6px;
 }
 
-/* 移动端侧边栏 */
+/* Mobile sidebar */
 .mobile-sidebar {
   position: fixed !important;
   top: 0;
   left: 0;
-  width: 300px !important;
+  width: 280px !important;
+  max-width: 85vw !important;
   height: 100vh !important;
   transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  z-index: 1000;
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1001;
+  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.12);
 }
 
 .mobile-sidebar.sidebar-visible {
   transform: translateX(0);
 }
 
-/* 移动端主内容 */
+/* Mobile overlay */
+.mobile-overlay {
+  background-color: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+/* Mobile content */
 .mobile-content {
-  margin-top: 60px;
-  height: calc(100vh - 60px) !important;
-  padding: 16px;
+  margin-top: 56px;
+  height: calc(100vh - 56px) !important;
   overflow-x: hidden;
 }
 
-/* 桌面端语言切换器 */
-.language-switcher-desktop {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 100;
+.mobile-content .editor-view-inner {
+  padding: 16px;
 }
 
-/* 移动端响应式 */
+/* Responsive */
 @media (max-width: 768px) {
   #app-layout {
     flex-direction: column;
   }
-  
+
   .main-content {
-    padding: 16px;
-    overflow-x: hidden;
+    padding: 0;
   }
-  
-  .main-content-inner {
-    max-width: 100%;
-  }
-  
+
   .editor-view-inner {
     padding: 16px;
-    overflow-x: hidden;
-  }
-  
-  /* 隐藏桌面端语言切换器 */
-  .language-switcher-desktop {
-    display: none;
+    max-width: 100%;
   }
 }
 
 @media (max-width: 480px) {
-  .mobile-content {
-    padding: 12px;
-    overflow-x: hidden;
-  }
-  
   .mobile-header {
-    height: 56px;
+    height: 52px;
   }
-  
+
   .mobile-content {
-    margin-top: 56px;
-    height: calc(100vh - 56px) !important;
+    margin-top: 52px;
+    height: calc(100vh - 52px) !important;
   }
-  
+
   .editor-view-inner {
     padding: 12px;
-    overflow-x: hidden;
   }
 }
 </style>

--- a/vue-frontend/src/components/AppSidebar.vue
+++ b/vue-frontend/src/components/AppSidebar.vue
@@ -1,19 +1,20 @@
 <template>
   <div class="app-sidebar">
-    <!-- 移动端关闭按钮 -->
+    <!-- Mobile close button -->
     <div class="mobile-close-btn" @click="$emit('close')">
       <el-icon><Close /></el-icon>
     </div>
 
+    <!-- Header -->
     <div class="sidebar-header">
       <img src="/img/index.png" alt="Logo" class="logo" />
       <h2>{{ $t('sidebar.title') }}</h2>
     </div>
 
+    <!-- Scrollable content -->
     <div class="sidebar-content">
-      <!-- 角色图片预览 -->
+      <!-- Character image -->
       <div class="character-image-section">
-        
         <div class="image-preview-wrapper">
           <img v-if="store.characterImageB64" :src="store.characterImageB64" :alt="$t('sidebar.image.preview')" class="image-preview" />
           <div v-else class="image-placeholder">
@@ -21,26 +22,24 @@
             <span>{{ $t('sidebar.image.placeholder') }}</span>
           </div>
         </div>
-        <!-- Removed original "更换图片" button here -->
       </div>
 
-      <!-- 操作按钮 -->
+      <!-- Export buttons -->
       <div class="actions-section">
         <div class="export-buttons-container">
-          <el-button 
-            type="primary" 
-            @click="store.exportCardAsImage()" 
-            :icon="Download" 
+          <el-button
+            type="primary"
+            @click="store.exportCardAsImage()"
+            :icon="Download"
             :disabled="!store.characterCard"
             :loading="store.isLoading"
             size="small"
           >
             {{ $t('sidebar.export.image') }}
           </el-button>
-
-          <el-button 
-            @click="store.exportCardAsJson()" 
-            :icon="Document" 
+          <el-button
+            @click="store.exportCardAsJson()"
+            :icon="Document"
             :disabled="!store.characterCard"
             size="small"
           >
@@ -49,87 +48,57 @@
         </div>
       </div>
 
-      <!-- 快速操作 -->
-      <div class="quick-actions-section">
-        
-        <div class="action-buttons-group">
-          <div class="action-buttons-row">
-            <!-- "上传卡片" button -->
-            <div class="action-button-wrapper">
-              <input type="file" ref="fileUploader" @change="handleFileChange" accept="image/png" style="display: none;" />
-              <el-button @click="triggerFileUpload" circle>
-                <el-icon><Upload /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.uploadCard') }}</span>
-            </div>
+      <!-- Action list - OpenAI style -->
+      <span class="section-label">{{ $t('sidebar.actions.title') }}</span>
+      <nav class="action-list">
+        <input type="file" ref="fileUploader" @change="handleFileChange" accept="image/png" style="display:none;" />
+        <input type="file" ref="jsonUploader" @change="handleJsonFileChange" accept="application/json" style="display:none;" />
+        <input type="file" ref="imageUploader" @change="handleImageChange" accept="image/png" style="display:none;" />
 
-            <!-- "上传JSON" button -->
-            <div class="action-button-wrapper">
-              <input type="file" ref="jsonUploader" @change="handleJsonFileChange" accept="application/json" style="display: none;" />
-              <el-button @click="triggerJsonUpload" circle>
-                <el-icon><FolderOpened /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.uploadJson') }}</span>
-            </div>
+        <button class="action-item" @click="triggerFileUpload">
+          <span class="action-icon"><el-icon><Upload /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.uploadCard') }}</span>
+        </button>
 
-            <!-- "新建空白卡" button -->
-            <div class="action-button-wrapper">
-              <el-button @click="createNewCard" circle>
-                <el-icon><DocumentAdd /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.newBlank') }}</span>
-            </div>
-          </div>
+        <button class="action-item" @click="triggerJsonUpload">
+          <span class="action-icon"><el-icon><FolderOpened /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.uploadJson') }}</span>
+        </button>
 
-          <div class="action-buttons-row">
-            <!-- "更换图片" button -->
-            <div class="action-button-wrapper">
-              <input type="file" ref="imageUploader" @change="handleImageChange" accept="image/png" style="display: none;" />
-              <el-button @click="triggerImageUpload" :disabled="!store.characterCard" circle>
-                <el-icon><Picture /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.changeImage') }}</span>
-            </div>
+        <button class="action-item" @click="createNewCard">
+          <span class="action-icon"><el-icon><DocumentAdd /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.newBlank') }}</span>
+        </button>
 
-            <!-- "翻译设置" button -->
-            <div class="action-button-wrapper">
-              <el-button @click="settingsDialogVisible = true" circle>
-                <el-icon><Setting /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.translationSettings') }}</span>
-            </div>
+        <button class="action-item" @click="triggerImageUpload" :disabled="!store.characterCard">
+          <span class="action-icon"><el-icon><Picture /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.changeImage') }}</span>
+        </button>
 
-            <!-- "清除卡片" button -->
-            <div class="action-button-wrapper">
-              <el-button @click="confirmReset" :disabled="!store.characterCard" circle type="danger">
-                <el-icon><Delete /></el-icon>
-              </el-button>
-              <span class="button-text">{{ $t('sidebar.actions.clearCard') }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
+        <button class="action-item" @click="settingsDialogVisible = true">
+          <span class="action-icon"><el-icon><Setting /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.translationSettings') }}</span>
+        </button>
+
+        <button class="action-item action-item--danger" @click="confirmReset" :disabled="!store.characterCard">
+          <span class="action-icon"><el-icon><Delete /></el-icon></span>
+          <span class="action-label">{{ $t('sidebar.actions.clearCard') }}</span>
+        </button>
+      </nav>
     </div>
 
-    <!-- 底部控制按钮 -->
-    <div class="sidebar-controls">
-      <div class="action-buttons-row">
-        <div class="action-button-wrapper">
-          <ThemeToggle />
-          <span class="button-text">{{ $t('sidebar.actions.theme') }}</span>
-        </div>
-        <div class="action-button-wrapper">
-          <LanguageSwitcher />
-          <span class="button-text">{{ $t('sidebar.actions.language') }}</span>
-        </div>
-      </div>
-    </div>
-
+    <!-- Bottom controls -->
     <div class="sidebar-footer">
-      <a href="https://github.com/nullskymc/tavernTranslator" target="_blank">{{ $t('sidebar.footer.github') }}</a>
+      <div class="footer-controls">
+        <ThemeToggle />
+        <LanguageSwitcher />
+      </div>
+      <a href="https://github.com/nullskymc/tavernTranslator" target="_blank" class="github-link">
+        {{ $t('sidebar.footer.github') }}
+      </a>
     </div>
 
-    <!-- 翻译设置对话框 -->
+    <!-- Settings dialog -->
     <TranslationSettingsDialog v-model="settingsDialogVisible" />
   </div>
 </template>
@@ -144,7 +113,6 @@ import TranslationSettingsDialog from './TranslationSettingsDialog.vue';
 import ThemeToggle from './ThemeToggle.vue';
 import LanguageSwitcher from './LanguageSwitcher.vue';
 
-// 定义emit事件
 const emit = defineEmits(['close']);
 
 const store = useTranslatorStore();
@@ -152,10 +120,9 @@ const { t: $t } = useI18n();
 
 const imageUploader = ref(null);
 const fileUploader = ref(null);
-const jsonUploader = ref(null); // 新增：JSON 文件上传的 ref
+const jsonUploader = ref(null);
 const settingsDialogVisible = ref(false);
 
-// --- 图片处理 ---
 const triggerImageUpload = () => imageUploader.value?.click();
 const handleImageChange = (event) => {
   const file = event.target.files[0];
@@ -166,170 +133,135 @@ const handleImageChange = (event) => {
   } else {
     ElMessage.error($t('messages.error.invalidPng'));
   }
-  event.target.value = ''; // 重置input，以便可以再次选择相同的文件
+  event.target.value = '';
 };
 
-// --- 文件上传处理 ---
 const triggerFileUpload = () => fileUploader.value?.click();
 const handleFileChange = (event) => {
   const file = event.target.files[0];
-  if (file) {
-    store.handleCardUpload(file);
-  }
-  event.target.value = ''; // 重置input
+  if (file) store.handleCardUpload(file);
+  event.target.value = '';
 };
 
-// --- JSON 文件上传处理 ---
 const triggerJsonUpload = () => jsonUploader.value?.click();
 const handleJsonFileChange = (event) => {
   const file = event.target.files[0];
   if (file && file.type === 'application/json') {
-    store.handleJsonUpload(file); // 调用 store 中的新方法
+    store.handleJsonUpload(file);
   } else {
     ElMessage.error($t('messages.error.invalidJson'));
   }
   event.target.value = '';
 };
 
-// --- 新建空白卡 ---
 const createNewCard = () => {
   ElMessageBox.confirm($t('sidebar.confirm.newBlank'), $t('messages.confirm.title'), {
-    confirmButtonText: $t('messages.confirm.confirm'), cancelButtonText: $t('messages.confirm.cancel'), type: 'warning',
-  }).then(() => store.createNewCard()).catch(() => {}); // 调用 store 中的新方法
+    confirmButtonText: $t('messages.confirm.confirm'),
+    cancelButtonText: $t('messages.confirm.cancel'),
+    type: 'warning',
+  }).then(() => store.createNewCard()).catch(() => {});
 };
 
-// --- 重置确认 ---
 const confirmReset = () => {
   ElMessageBox.confirm($t('sidebar.confirm.clearCard'), $t('messages.confirm.title'), {
-    confirmButtonText: $t('messages.confirm.confirm'), cancelButtonText: $t('messages.confirm.cancel'), type: 'warning',
+    confirmButtonText: $t('messages.confirm.confirm'),
+    cancelButtonText: $t('messages.confirm.cancel'),
+    type: 'warning',
   }).then(() => store.resetStore()).catch(() => {});
 };
 </script>
 
 <style scoped>
+/* ===========================
+   Sidebar - OpenAI style
+   =========================== */
 .app-sidebar {
-  width: 300px;
+  /* Flexible width: shrinks to ~220px, grows up to 280px based on content */
+  width: fit-content;
+  min-width: 220px;
+  max-width: 280px;
   height: 100vh;
-  background-color: var(--apple-bg-color-tertiary);
+  background-color: var(--apple-bg-sidebar);
   border-right: 1px solid var(--apple-border-color);
   display: flex;
   flex-direction: column;
-  padding: 20px;
+  padding: 0;
   box-sizing: border-box;
   position: relative;
-  flex-shrink: 0; /* 防止被压缩 */
-  margin: 0; /* 确保没有外边距 */
-  z-index: 1; /* 确保在正确层级 */
+  flex-shrink: 0;
+  z-index: 1;
+  /* overflow: hidden removed — let flex column children clip themselves */
 }
 
-/* 暗色主题下的侧边栏样式 */
-.dark-theme .app-sidebar {
-  background-color: var(--el-bg-color);
-  border-right: 1px solid var(--el-border-color);
-}
-
-/* 暗色主题下的边框修复 */
-.dark-theme .sidebar-header {
-  border-bottom: 1px solid var(--el-border-color);
-}
-
-.dark-theme .sidebar-footer {
-  border-top: 1px solid var(--el-border-color);
-}
-
-.dark-theme .sidebar-controls {
-  border-top: 1px solid var(--el-border-color);
-  border-bottom: 1px solid var(--el-border-color);
-}
-
-/* 文字颜色修复 */
-.dark-theme .sidebar-header h2 {
-  color: var(--el-text-color-primary);
-}
-
-.dark-theme .sidebar-footer a {
-  color: var(--el-text-color-secondary);
-}
-
-.dark-theme .sidebar-footer a:hover {
-  color: var(--el-color-primary);
-}
-
-/* 移动端关闭按钮 */
+/* Mobile close button */
 .mobile-close-btn {
   display: none;
   position: absolute;
-  top: 16px;
-  right: 16px;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background-color: var(--el-fill-color-light);
+  top: 14px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--apple-border-radius-medium);
+  background-color: var(--apple-color-gray-5);
   cursor: pointer;
   align-items: center;
   justify-content: center;
   z-index: 10;
-  transition: background-color 0.2s;
+  transition: background-color var(--apple-transition-duration) var(--apple-transition-easing);
+  color: var(--apple-text-color-secondary);
+  font-size: 14px;
 }
 
 .mobile-close-btn:hover {
-  background-color: var(--el-fill-color);
-}
-
-.dark-theme .mobile-close-btn {
-  background-color: var(--el-fill-color-light);
-}
-
-.dark-theme .mobile-close-btn:hover {
-  background-color: var(--el-fill-color);
-}
-
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid var(--apple-border-color);
-}
-
-.logo {
-  width: 40px;
-  height: 40px;
-  border-radius: var(--apple-border-radius-full);
-}
-
-.sidebar-header h2 {
-  font-size: 1.2em;
-  font-weight: 600;
-  margin: 0;
+  background-color: var(--apple-color-gray-4);
   color: var(--apple-text-color-primary);
 }
 
+/* Header */
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 16px 14px;
+  border-bottom: 1px solid var(--apple-border-color);
+  flex-shrink: 0;
+}
+
+.logo {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--apple-border-radius-medium);
+  flex-shrink: 0;
+}
+
+.sidebar-header h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--apple-text-color-primary);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Content scroll area */
 .sidebar-content {
   flex-grow: 1;
   overflow-y: auto;
-  margin-top: 20px;
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
-  padding: 10px;
-  border-radius: var(--apple-border-radius-medium);
-  background-color: var(--apple-bg-color);
-  box-shadow: var(--apple-shadow-small);
+  overflow-x: hidden;
+  padding: 12px 8px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .sidebar-content::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, and Opera */
+  display: none;
 }
 
-.section-title {
-  font-size: 0.9em;
-  color: var(--el-text-color-secondary);
-  margin-bottom: 10px;
-  font-weight: 500;
-}
-
-.character-image-section, .settings-section {
-  margin-bottom: 25px;
+/* Image section */
+.character-image-section {
+  margin-bottom: 12px;
 }
 
 .image-preview-wrapper {
@@ -337,9 +269,7 @@ const confirmReset = () => {
   aspect-ratio: 1 / 1;
   border-radius: var(--apple-border-radius-large);
   overflow: hidden;
-  margin-bottom: 10px;
-  background-color: var(--apple-bg-color-secondary);
-  box-shadow: var(--apple-shadow-small);
+  background-color: var(--apple-color-gray-5);
   border: 1px solid var(--apple-border-color);
 }
 
@@ -347,6 +277,7 @@ const confirmReset = () => {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
 }
 
 .image-placeholder {
@@ -356,274 +287,186 @@ const confirmReset = () => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: var(--apple-text-color-secondary);
+  gap: 6px;
+  color: var(--apple-text-color-tertiary);
+  font-size: 11px;
 }
 
 .image-placeholder .el-icon {
-  font-size: 48px;
+  font-size: 28px;
   color: var(--apple-color-gray-3);
 }
 
+/* Export section */
 .actions-section {
-  margin-bottom: 25px;
+  margin-bottom: 8px;
 }
 
 .export-buttons-container {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   width: 100%;
 }
 
 .export-buttons-container .el-button {
-  flex: 1;
+  flex: 1 1 0;       /* grow equally but allow shrink */
+  min-width: 0;      /* allow content to shrink below intrinsic size */
   justify-content: center;
+  font-size: 12px;
+  height: auto;
+  min-height: 30px;
+  padding: 4px 8px;
+  white-space: normal;   /* let text wrap on narrow widths */
+  line-height: 1.3;
+  word-break: break-word;
 }
 
-
-
-
-
-
-.settings-section .el-button {
-  width: 100%;
-  justify-content: flex-start;
-  padding: 8px 12px;
+/* Section label */
+.section-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--apple-text-color-tertiary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 8px 8px 4px;
 }
 
-.quick-actions-section {
-  margin-bottom: 25px;
-}
-
-.action-buttons-group {
+/* Action list - OpenAI nav item style */
+.action-list {
   display: flex;
   flex-direction: column;
-  gap: 10px; /* 行之间的间距 */
+  gap: 1px;
 }
 
-.action-buttons-row {
+.action-item {
   display: flex;
-  justify-content: space-around;
-  gap: 10px; /* 按钮之间的间距 */
-}
-
-.action-button-wrapper {
-  display: flex;
-  align-items: center; /* 垂直居中 */
-  justify-content: flex-start; /* 初始左对齐 */
-  position: relative;
-  width: 50px; /* 初始宽度，与按钮直径相同 */
-  height: 50px; /* 与按钮直径相同 */
-  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
-  border-radius: var(--apple-border-radius-full); /* 圆角 */
-  overflow: hidden; /* 隐藏溢出的文本 */
-  background-color: var(--apple-bg-color-secondary);
-  box-sizing: border-box;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--apple-border-radius-medium);
+  border: none;
+  background: transparent;
   cursor: pointer;
-  box-shadow: var(--apple-shadow-small);
-}
-
-.dark-theme .action-button-wrapper {
-  background-color: var(--apple-bg-color-secondary) !important;
-}
-
-.action-button-wrapper:hover {
-  width: 120px; /* 悬停时展开的宽度 */
-  background-color: var(--apple-color-primary);
-}
-
-.dark-theme .action-button-wrapper:hover {
-  background-color: var(--apple-color-primary) !important;
-}
-
-/* 修复按钮 hover 时变成蓝色的问题 */
-.action-button-wrapper:hover .el-button:not(.el-button--danger) {
-  background-color: var(--apple-color-primary);
-  border-color: var(--apple-color-primary);
-  color: var(--apple-text-color-inverse);
-}
-
-/* 确保危险按钮在 hover 时保持红色 */
-.action-button-wrapper:hover .el-button--danger {
-  background-color: var(--el-color-danger-dark-2);
-  border-color: var(--el-color-danger-dark-2);
-  color: var(--apple-text-color-inverse);
-}
-
-/* 暗色主题下的按钮样式 */
-.dark-theme .action-button-wrapper .el-button {
-  background-color: var(--apple-bg-color-tertiary);
-  border-color: var(--apple-border-color);
   color: var(--apple-text-color-primary);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  text-align: left;
+  transition: background-color var(--apple-transition-duration) var(--apple-transition-easing);
+  line-height: 1.4;
 }
 
-.dark-theme .action-button-wrapper:hover .el-button:not(.el-button--danger) {
-  background-color: var(--apple-color-primary);
-  border-color: var(--apple-color-primary);
-  color: var(--apple-text-color-inverse);
+.action-item:hover {
+  background-color: var(--apple-color-gray-5);
 }
 
-.dark-theme .action-button-wrapper:hover .el-button--danger {
-  background-color: var(--el-color-danger-dark-2);
-  border-color: var(--el-color-danger-dark-2);
-  color: var(--apple-text-color-inverse);
+.action-item:active {
+  background-color: var(--apple-color-gray-4);
 }
 
-.action-button-wrapper .el-button {
-  width: 50px;
-  height: 50px;
-  border-radius: var(--apple-border-radius-full);
+.action-item:disabled {
+  color: var(--apple-text-color-tertiary);
+  cursor: not-allowed;
+}
+
+.action-item:disabled:hover {
+  background: transparent;
+}
+
+.action-item--danger {
+  color: var(--apple-color-danger);
+}
+
+.action-item--danger:hover {
+  background-color: rgba(239, 68, 68, 0.08);
+}
+
+.action-icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  flex-shrink: 0; /* 防止按钮在父容器展开时被压缩 */
-  background-color: var(--apple-bg-color-tertiary);
-  border: 1px solid var(--apple-border-color);
-  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  font-size: 15px;
+  color: var(--apple-text-color-secondary);
 }
 
-/* 确保危险按钮类型正确显示 */
-.action-button-wrapper .el-button--danger {
-  background-color: var(--el-color-danger);
-  border-color: var(--el-color-danger);
-  color: var(--el-bg-color);
+.action-item--danger .action-icon {
+  color: var(--apple-color-danger);
 }
 
-.action-button-wrapper .el-button--danger:hover {
-  background-color: var(--el-color-danger-dark-2);
-  border-color: var(--el-color-danger-dark-2);
+.action-item:disabled .action-icon {
+  color: var(--apple-text-color-tertiary);
 }
 
-.action-button-wrapper .button-text {
+.action-label {
+  flex: 1;
   white-space: nowrap;
-  opacity: 0;
-  transition: opacity var(--apple-transition-duration) var(--apple-transition-easing);
-  color: var(--apple-text-color-primary);
-  font-size: 0.8em;
-  margin-left: 8px; /* 文本与图标的间距 */
-  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.action-button-wrapper:hover .button-text {
-  opacity: 1;
-  color: var(--apple-text-color-inverse);
-}
-
+/* Footer */
 .sidebar-footer {
-  padding-top: 20px;
-  border-top: 1px solid var(--el-border-color-light);
-  text-align: center;
+  flex-shrink: 0;
+  padding: 10px 8px;
+  border-top: 1px solid var(--apple-border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.sidebar-footer a {
-  color: var(--el-text-color-secondary);
+.footer-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.github-link {
+  font-size: 11px;
+  color: var(--apple-text-color-tertiary);
   text-decoration: none;
-  font-size: 0.9em;
-}
-.sidebar-footer a:hover {
-  color: var(--el-color-primary);
-}
-
-.sidebar-controls {
-  padding: 16px 0;
-  border-top: 1px solid var(--el-border-color-light);
-  border-bottom: 1px solid var(--el-border-color-light);
-  margin: 0 20px;
+  text-align: center;
+  display: block;
+  transition: color var(--apple-transition-duration) var(--apple-transition-easing);
 }
 
-/* 移动端样式 */
+.github-link:hover {
+  color: var(--apple-text-color-secondary);
+}
+
+/* Mobile */
 @media (max-width: 768px) {
   .mobile-close-btn {
     display: flex;
   }
-  
-  .app-sidebar {
-    padding: 16px;
-  }
-  
+
   .sidebar-header {
-    padding-top: 40px; /* 为关闭按钮留出空间 */
+    padding-top: 52px;
   }
-  
-  .character-image-section {
-    margin-bottom: 20px;
-  }
-  
+
   .image-preview-wrapper {
-    max-width: 200px;
-    margin: 0 auto 10px;
+    max-width: 180px;
+    margin: 0 auto;
   }
-  
-  .action-buttons-row {
-    flex-direction: column;
-    gap: 8px;
-  }
-  
-  .action-button-wrapper, .theme-toggle, .language-switcher {
-    width: 100%;
-    height: 50px;
-    border-radius: 25px;
-    justify-content: flex-start;
-    padding: 0 16px;
-  }
-  
-  .action-button-wrapper:hover, .theme-toggle:hover, .language-switcher:hover {
-    width: 100%;
-  }
-  
-  .action-button-wrapper .button-text, .theme-toggle .button-text, .language-switcher .button-text {
-    opacity: 1;
-    margin-left: 12px;
-  }
-  
-  .export-buttons-wrapper {
-    gap: 8px;
-  }
-  
-  .sidebar-controls {
-    margin: 0 16px;
-  }
-  
-  .sidebar-controls .action-buttons-row {
-    gap: 8px;
+
+  .action-item {
+    padding: 10px 12px;
+    font-size: 14px;
   }
 }
 
 @media (max-width: 480px) {
   .app-sidebar {
-    width: 280px;
-    padding: 12px;
+    min-width: 240px;
+    max-width: 280px;
   }
-  
-  .sidebar-header h2 {
-    font-size: 1.1em;
-  }
-  
-  .logo {
-    width: 36px;
-    height: 36px;
-  }
-  
+
   .image-preview-wrapper {
-    max-width: 150px;
-  }
-  
-  .action-button-wrapper, .theme-toggle, .language-switcher {
-    height: 45px;
-    padding: 0 12px;
-  }
-  
-  .action-button-wrapper .el-button, .theme-toggle .theme-button, .language-switcher .language-button {
-    width: 45px;
-    height: 45px;
-  }
-  
-  .action-button-wrapper .button-text, .theme-toggle .button-text, .language-switcher .button-text {
-    font-size: 0.85em;
-  }
-  
-  .sidebar-controls {
-    margin: 0 12px;
+    max-width: 140px;
   }
 }
 </style>

--- a/vue-frontend/src/components/CharacterBookEditor.vue
+++ b/vue-frontend/src/components/CharacterBookEditor.vue
@@ -295,13 +295,11 @@ const translateContent = async (index: number) => {
   }
 };
 
-  // 视图切换：先更新本地视图让指示条动画，再延迟通知父级切换
+  // 视图切换：下划线 tab 无需动画延迟，直接切换
   const switchView = (view: string) => {
     if (localView.value === view) return;
     localView.value = view;
-    setTimeout(() => {
-      window.dispatchEvent(new CustomEvent('view-change', { detail: { view } }));
-    }, 220);
+    window.dispatchEvent(new CustomEvent('view-change', { detail: { view } }));
   };
 
   // 批量翻译功能
@@ -343,37 +341,55 @@ const translateContent = async (index: number) => {
 }
 
 .entries-section {
-  margin-top: 30px;
+  margin-top: 24px;
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
+/* Section header: flat, no heavy h3 weight */
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .section-header h3 {
   margin: 0;
-  font-size: 1.1em;
+  font-size: 11px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--el-text-color-secondary);
 }
 
 .entry-item {
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
+/* Flat card for each entry — thin border, no shadow */
 .entry-card {
   border: 1px solid var(--el-border-color-light);
+  box-shadow: none;
+  border-radius: 6px;
+}
+
+:deep(.entry-card .el-card__header) {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+  background: var(--el-fill-color-lighter);
 }
 
 .entry-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--el-text-color-secondary);
 }
 
 .no-book-content {
@@ -385,33 +401,12 @@ const translateContent = async (index: number) => {
   gap: 20px;
 }
 
-/* 移动端样式 */
+/* Mobile */
 @media (max-width: 768px) {
-  .character-book-editor {
-    padding: 0;
-  }
-  
-  .book-form .el-col {
-    padding: 0 5px;
-  }
-  
   .section-header {
     flex-direction: column;
     align-items: stretch;
     gap: 10px;
-  }
-  
-  .entry-item {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 8px;
-  }
-  
-  .entry-actions {
-    flex-direction: row;
-    justify-content: space-between;
-    margin-left: 0;
-    gap: 8px;
   }
 }
 
@@ -419,19 +414,9 @@ const translateContent = async (index: number) => {
   .book-form .el-form-item {
     margin-bottom: 16px;
   }
-  
+
   .book-form .el-col {
     padding: 0 2px;
-  }
-  
-  .entry-actions .el-button {
-    font-size: 12px;
-    padding: 4px 8px;
-  }
-  
-  .translate-btn {
-    font-size: 12px;
-    padding: 2px 6px;
   }
 }
 </style>

--- a/vue-frontend/src/components/CharacterEditor.vue
+++ b/vue-frontend/src/components/CharacterEditor.vue
@@ -215,14 +215,11 @@ const batchTranslate = async () => {
     isBatchTranslating.value = false;
   }
 };
-// 视图切换：先更新本地视图让指示条动画，再延迟通知父级切换
+// 视图切换：下划线 tab 无需动画延迟，直接切换
 function switchView(view: string) {
   if (localView.value === view) return;
   localView.value = view;
-  // 等待指示条动画 (~200ms) 完成后再切换父视图
-  setTimeout(() => {
-    window.dispatchEvent(new CustomEvent('view-change', { detail: { view } }));
-  }, 220);
+  window.dispatchEvent(new CustomEvent('view-change', { detail: { view } }));
 }
 
 </script>
@@ -240,75 +237,37 @@ function switchView(view: string) {
   overflow-x: hidden;
 }
 
-.translate-btn { 
-  margin-left: 10px; 
-}
-
-.greeting-item { 
-  display: flex; 
-  align-items: center; 
-  margin-bottom: 10px; 
-  width: 100%; 
-}
-
-.greeting-item .el-input { 
-  flex-grow: 1; 
-}
-
-.greeting-actions { 
-  display: flex; 
-  flex-direction: column; 
-  margin-left: 8px; 
-}
-
-.label-with-btn {
+/* Alternate greeting row */
+.greeting-item {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
   width: 100%;
 }
 
-.label-with-btn .translate-btn {
-  margin-left: 10px;
+.greeting-item .el-input {
+  flex-grow: 1;
 }
 
-/* 移动端样式 */
+.greeting-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+/* Mobile */
 @media (max-width: 768px) {
-  .character-editor {
-    padding: 0;
-  }
-  
-  .editor-form .el-col {
-    padding: 0 5px;
-  }
-  
   .greeting-item {
     flex-direction: column;
     align-items: stretch;
-    gap: 8px;
   }
-  
+
   .greeting-actions {
     flex-direction: row;
-    justify-content: space-between;
-    margin-left: 0;
+    justify-content: flex-end;
     gap: 8px;
-  }
-  
-  .translate-btn {
-    margin-left: 0;
-    margin-top: 4px;
-  }
-  
-  .label-with-btn {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-  }
-  
-  .label-with-btn .translate-btn {
-    margin-left: 0;
-    align-self: flex-end;
   }
 }
 
@@ -316,19 +275,14 @@ function switchView(view: string) {
   .editor-form .el-form-item {
     margin-bottom: 16px;
   }
-  
+
   .editor-form .el-col {
     padding: 0 2px;
   }
-  
+
   .greeting-actions .el-button {
     font-size: 12px;
     padding: 4px 8px;
-  }
-  
-  .translate-btn {
-    font-size: 12px;
-    padding: 2px 6px;
   }
 }
 </style>

--- a/vue-frontend/src/components/LanguageSwitcher.vue
+++ b/vue-frontend/src/components/LanguageSwitcher.vue
@@ -1,36 +1,17 @@
 <template>
-  <el-button class="language-button" circle @click="toggleLanguage">
-    <el-icon><Switch /></el-icon>
-  </el-button>
+  <el-tooltip :content="currentLanguage === 'zh' ? 'Switch to English' : '切换为中文'" placement="top">
+    <button class="control-btn" @click="toggleLanguage" :aria-label="currentLanguage === 'zh' ? 'Switch to English' : 'Switch to Chinese'">
+      <span class="lang-label">{{ currentLanguage === 'zh' ? 'ZH' : 'EN' }}</span>
+    </button>
+  </el-tooltip>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { Switch } from '@element-plus/icons-vue';
 
 const { locale } = useI18n();
 const currentLanguage = ref(locale.value);
-
-// 移动端检测
-const isMobile = ref(false);
-
-const checkMobile = () => {
-  isMobile.value = window.innerWidth <= 768;
-};
-
-const handleResize = () => {
-  checkMobile();
-};
-
-onMounted(() => {
-  checkMobile();
-  window.addEventListener('resize', handleResize);
-});
-
-onUnmounted(() => {
-  window.removeEventListener('resize', handleResize);
-});
 
 const toggleLanguage = () => {
   const newLang = currentLanguage.value === 'zh' ? 'en' : 'zh';
@@ -41,90 +22,35 @@ const toggleLanguage = () => {
 </script>
 
 <style scoped>
-
-
-.language-button {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
+.control-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--apple-border-radius-medium);
+  border: 1px solid var(--apple-border-color);
+  background-color: var(--apple-bg-color);
+  color: var(--apple-text-color-secondary);
+  cursor: pointer;
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
   flex-shrink: 0;
-  background-color: var(--el-fill-color-light);
-  border: none;
-  color: var(--el-text-color-primary);
 }
 
-.language-button:hover {
-  background-color: var(--el-color-primary-light-9);
+.control-btn:hover {
+  background-color: var(--apple-color-gray-5);
+  color: var(--apple-text-color-primary);
+  border-color: var(--apple-border-color-strong);
 }
 
-.language-button .el-icon {
-  font-size: 18px;
-  transition: color 0.3s ease;
+.control-btn:active {
+  background-color: var(--apple-color-gray-4);
 }
 
-.button-text {
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  color: var(--el-text-color-primary);
-  font-size: 0.8em;
-  margin-left: 8px;
-}
-
-.dark-theme .button-text {
-  color: var(--text-primary) !important;
-}
-
-.language-switcher:hover .button-text {
-  opacity: 1;
-}
-
-/* 移动端样式 */
-@media (max-width: 768px) {
-  .language-switcher {
-    width: 100%;
-    height: 50px;
-    border-radius: 25px;
-    justify-content: flex-start;
-    padding: 0 16px;
-  }
-  
-  .language-switcher:hover {
-    width: 100%;
-  }
-  
-  .language-button {
-    width: 50px;
-    height: 50px;
-  }
-  
-  .button-text {
-    opacity: 1;
-    margin-left: 12px;
-  }
-}
-
-@media (max-width: 480px) {
-  .language-switcher {
-    height: 45px;
-    padding: 0 12px;
-  }
-  
-  .language-button {
-    width: 45px;
-    height: 45px;
-  }
-  
-  .language-button .el-icon {
-    font-size: 16px;
-  }
-  
-  .button-text {
-    font-size: 0.85em;
-  }
+.lang-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
 }
 </style>

--- a/vue-frontend/src/components/ThemeToggle.vue
+++ b/vue-frontend/src/components/ThemeToggle.vue
@@ -1,104 +1,47 @@
 <template>
-  <el-button class="theme-button" circle @click="toggleTheme">
-    <el-icon><component :is="isDarkTheme ? Sunny : Moon" /></el-icon>
-  </el-button>
+  <el-tooltip :content="isDarkTheme ? $t('sidebar.actions.theme') + ' (Light)' : $t('sidebar.actions.theme') + ' (Dark)'" placement="top">
+    <button class="control-btn" @click="toggleTheme" :aria-label="isDarkTheme ? 'Switch to light mode' : 'Switch to dark mode'">
+      <el-icon><component :is="isDarkTheme ? Sunny : Moon" /></el-icon>
+    </button>
+  </el-tooltip>
 </template>
 
 <script setup lang="ts">
-import { storeToRefs } from 'pinia'
-import { useThemeStore } from '../stores/theme'
-import { Sunny, Moon } from '@element-plus/icons-vue'
+import { storeToRefs } from 'pinia';
+import { useThemeStore } from '../stores/theme';
+import { Sunny, Moon } from '@element-plus/icons-vue';
+import { useI18n } from 'vue-i18n';
 
-const themeStore = useThemeStore()
-const { isDarkTheme } = storeToRefs(themeStore)
-const { toggleTheme } = themeStore
+const { t: $t } = useI18n();
+const themeStore = useThemeStore();
+const { isDarkTheme } = storeToRefs(themeStore);
+const { toggleTheme } = themeStore;
 </script>
 
 <style scoped>
-
-
-.theme-button {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
+.control-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--apple-border-radius-medium);
+  border: 1px solid var(--apple-border-color);
+  background-color: var(--apple-bg-color);
+  color: var(--apple-text-color-secondary);
+  cursor: pointer;
+  font-size: 15px;
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
   flex-shrink: 0;
-  background-color: var(--el-fill-color-light);
-  border: none;
-  color: var(--el-text-color-primary);
 }
 
-.theme-button:hover {
-  background-color: var(--el-color-primary-light-9);
+.control-btn:hover {
+  background-color: var(--apple-color-gray-5);
+  color: var(--apple-text-color-primary);
+  border-color: var(--apple-border-color-strong);
 }
 
-.theme-button .el-icon {
-  font-size: 18px;
-  transition: color 0.3s ease;
-}
-
-.button-text {
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  color: var(--el-text-color-primary);
-  font-size: 0.8em;
-  margin-left: 8px;
-}
-
-.dark-theme .button-text {
-  color: var(--text-primary) !important;
-}
-
-.theme-toggle:hover .button-text {
-  opacity: 1;
-}
-
-/* 移动端样式 */
-@media (max-width: 768px) {
-  .theme-toggle {
-    width: 100%;
-    height: 50px;
-    border-radius: 25px;
-    justify-content: flex-start;
-    padding: 0 16px;
-  }
-  
-  .theme-toggle:hover {
-    width: 100%;
-  }
-  
-  .theme-button {
-    width: 50px;
-    height: 50px;
-  }
-  
-  .button-text {
-    opacity: 1;
-    margin-left: 12px;
-  }
-}
-
-@media (max-width: 480px) {
-  .theme-toggle {
-    height: 45px;
-    padding: 0 12px;
-  }
-  
-  .theme-button {
-    width: 45px;
-    height: 45px;
-  }
-  
-  .theme-button .el-icon {
-    font-size: 16px;
-  }
-  
-  .button-text {
-    font-size: 0.85em;
-  }
+.control-btn:active {
+  background-color: var(--apple-color-gray-4);
 }
 </style>

--- a/vue-frontend/src/components/TranslationSettingsDialog.vue
+++ b/vue-frontend/src/components/TranslationSettingsDialog.vue
@@ -129,3 +129,76 @@ const saveSettings = () => {
   dialogVisible.value = false;
 };
 </script>
+
+<style scoped>
+/* Tighten the form to match the flat OpenAI aesthetic */
+:deep(.el-dialog__header) {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--el-border-color-light);
+  margin-right: 0;
+}
+
+:deep(.el-dialog__title) {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--el-text-color-primary);
+}
+
+:deep(.el-dialog__body) {
+  padding: 20px 24px;
+}
+
+:deep(.el-dialog__footer) {
+  padding: 12px 24px 20px;
+  border-top: 1px solid var(--el-border-color-light);
+}
+
+/* Form labels: uppercase micro-label style */
+:deep(.el-form-item__label) {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--el-text-color-secondary);
+  line-height: 1.4;
+  padding-bottom: 6px;
+}
+
+/* Tighter form item spacing */
+:deep(.el-form-item) {
+  margin-bottom: 16px;
+}
+
+/* Collapse section — flat, no card shadow */
+:deep(.el-collapse) {
+  border-top: 1px solid var(--el-border-color-light);
+  border-bottom: none;
+  margin-top: 4px;
+}
+
+:deep(.el-collapse-item__header) {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--el-text-color-secondary);
+  height: 40px;
+  line-height: 40px;
+}
+
+:deep(.el-collapse-item__content) {
+  padding-bottom: 12px;
+}
+
+/* Radio buttons */
+:deep(.el-radio__label) {
+  font-size: 13px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/vue-frontend/src/components/WelcomeView.vue
+++ b/vue-frontend/src/components/WelcomeView.vue
@@ -1,248 +1,282 @@
 <template>
-  <div class="welcome-container">
-    <h1 class="title">{{ $t('welcome.title') }}</h1>
-    <p class="subtitle">{{ $t('welcome.subtitle') }}</p>
-    
-    <div class="features">
-      <div class="feature-item">
-        <el-icon><EditPen /></el-icon>
-        <span>{{ $t('welcome.features.onlineEdit') }}</span>
+  <div
+    class="welcome-container"
+    :class="{ 'is-dragover': isDragover }"
+    @dragover.prevent="isDragover = true"
+    @dragleave.prevent="isDragover = false"
+    @drop.prevent="handleDrop"
+  >
+    <div class="welcome-content">
+      <!-- Logo / Icon area -->
+      <div class="hero-icon">
+        <img src="/img/index.png" alt="TavernTranslator" class="hero-logo" />
       </div>
-      <div class="feature-item">
-        <el-icon><DataLine /></el-icon>
-        <span>{{ $t('welcome.features.localStorage') }}</span>
-      </div>
-      <div class="feature-item">
-        <el-icon><Switch /></el-icon>
-        <span>{{ $t('welcome.features.oneClickTranslate') }}</span>
-      </div>
-      <div class="feature-item">
-        <el-icon><Download /></el-icon>
-        <span>{{ $t('welcome.features.imageExport') }}</span>
-      </div>
-    </div>
 
-    <div class="instructions">
-      <i18n-t keypath="welcome.instructions" tag="p">
-        <template #uploadButton>
-          <strong>{{ $t('sidebar.actions.uploadCard') }}</strong>
-        </template>
-        <template #pngCode>
-          <code>.png</code>
-        </template>
-        <template #githubLink>
-          <a href="https://github.com/nullskymc/tavernTranslator" target="_blank">{{ $t('welcome.instructionsGithubLinkText') }}</a>
-        </template>
-      </i18n-t>
+      <h1 class="hero-title">{{ $t('welcome.title') }}</h1>
+      <p class="hero-subtitle">{{ $t('welcome.subtitle') }}</p>
+
+      <!-- Feature pills -->
+      <div class="features">
+        <div class="feature-pill">
+          <el-icon><EditPen /></el-icon>
+          <span>{{ $t('welcome.features.onlineEdit') }}</span>
+        </div>
+        <div class="feature-pill">
+          <el-icon><DataLine /></el-icon>
+          <span>{{ $t('welcome.features.localStorage') }}</span>
+        </div>
+        <div class="feature-pill">
+          <el-icon><Switch /></el-icon>
+          <span>{{ $t('welcome.features.oneClickTranslate') }}</span>
+        </div>
+        <div class="feature-pill">
+          <el-icon><Download /></el-icon>
+          <span>{{ $t('welcome.features.imageExport') }}</span>
+        </div>
+      </div>
+
+      <!-- Drop zone hint -->
+      <div class="drop-hint">
+        <el-icon class="drop-icon"><Upload /></el-icon>
+        <div class="drop-text">
+          <i18n-t keypath="welcome.instructions" tag="span">
+            <template #uploadButton>
+              <strong>{{ $t('sidebar.actions.uploadCard') }}</strong>
+            </template>
+            <template #pngCode>
+              <code>.png</code>
+            </template>
+            <template #githubLink>
+              <a href="https://github.com/nullskymc/tavernTranslator" target="_blank">{{ $t('welcome.instructionsGithubLinkText') }}</a>
+            </template>
+          </i18n-t>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { EditPen, DataLine, Switch, Download } from '@element-plus/icons-vue';
+import { ref } from 'vue';
+import { EditPen, DataLine, Switch, Download, Upload } from '@element-plus/icons-vue';
 import { useTranslatorStore } from '@/stores/translator';
 
 const store = useTranslatorStore();
+const isDragover = ref(false);
 
-// 拖拽上传逻辑
-const setupDragAndDrop = (element) => {
-  element.addEventListener('dragover', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    element.classList.add('dragover');
-  });
-
-  element.addEventListener('dragleave', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    element.classList.remove('dragover');
-  });
-
-  element.addEventListener('drop', (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    element.classList.remove('dragover');
-    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      const file = e.dataTransfer.files[0];
-      if (file.type === 'image/png') {
-        store.handleCardUpload(file);
-      }
+const handleDrop = (e: DragEvent) => {
+  isDragover.value = false;
+  if (e.dataTransfer?.files?.[0]) {
+    const file = e.dataTransfer.files[0];
+    if (file.type === 'image/png') {
+      store.handleCardUpload(file);
     }
-  });
+  }
 };
-
-import { onMounted, onUnmounted } from 'vue';
-let container = null;
-onMounted(() => {
-  container = document.querySelector('.welcome-container');
-  if (container) {
-    setupDragAndDrop(container);
-  }
-});
-onUnmounted(() => {
-  if (container) {
-    // 移除事件监听器以防内存泄漏
-  }
-});
 </script>
 
 <style scoped>
 .welcome-container {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  text-align: center;
-  border: 2px dashed var(--apple-border-color);
-  border-radius: var(--apple-border-radius-large);
-  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
+  flex: 1;
+  min-height: 100%;
+  padding: 40px 24px;
+  box-sizing: border-box;
+  transition: background-color var(--apple-transition-duration) var(--apple-transition-easing);
   background-color: var(--apple-bg-color);
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 40px;
 }
 
-.welcome-container.dragover {
-  background-color: var(--apple-color-primary-light);
-  border-color: var(--apple-color-primary);
+.welcome-container.is-dragover {
+  background-color: var(--apple-color-primary-alpha);
 }
 
-.title {
-  font-size: 2.5em;
+.welcome-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 520px;
+  width: 100%;
+  animation: fadeIn 0.4s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Hero icon */
+.hero-icon {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 24px;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: var(--apple-shadow-medium);
+}
+
+.hero-logo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Titles */
+.hero-title {
+  font-size: 28px;
   font-weight: 700;
   color: var(--apple-text-color-primary);
-  margin-bottom: 10px;
+  margin: 0 0 10px;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
 }
 
-.subtitle {
-  font-size: 1.2em;
+.hero-subtitle {
+  font-size: 15px;
   color: var(--apple-text-color-secondary);
-  margin-bottom: 40px;
-}
-
-.features {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-  margin-bottom: 40px;
-  flex-wrap: wrap;
-}
-
-.feature-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 1em;
-  color: var(--apple-text-color-primary);
-  flex-direction: column;
-  text-align: center;
-  min-width: 80px;
-  padding: 12px;
-  border-radius: var(--apple-border-radius-medium);
-  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
-}
-
-.feature-item:hover {
-  background-color: var(--apple-bg-color-secondary);
-}
-
-.feature-item .el-icon {
-  color: var(--apple-color-primary);
-  font-size: 24px;
-}
-
-.instructions {
-  font-size: 1em;
-  color: var(--el-text-color-secondary);
+  margin: 0 0 32px;
   line-height: 1.6;
 }
 
-.instructions code {
-  background-color: var(--el-fill-color-light);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: 'Courier New', monospace;
+/* Feature pills */
+.features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 40px;
 }
 
-.instructions a {
-  color: var(--el-color-primary);
-  text-decoration: none;
+.feature-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--apple-border-radius-full);
+  border: 1px solid var(--apple-border-color);
+  background-color: var(--apple-bg-color-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--apple-text-color-secondary);
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
 }
 
-.instructions a:hover {
+.feature-pill:hover {
+  border-color: var(--apple-color-primary);
+  color: var(--apple-color-primary);
+  background-color: var(--apple-color-primary-alpha);
+}
+
+.feature-pill .el-icon {
+  font-size: 13px;
+  color: var(--apple-color-primary);
+}
+
+/* Drop zone */
+.drop-hint {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 24px 32px;
+  border: 1.5px dashed var(--apple-border-color-strong);
+  border-radius: var(--apple-border-radius-xl);
+  background-color: var(--apple-bg-color-secondary);
+  width: 100%;
+  box-sizing: border-box;
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
+}
+
+.welcome-container.is-dragover .drop-hint {
+  border-color: var(--apple-color-primary);
+  background-color: var(--apple-color-primary-alpha);
+}
+
+.drop-icon {
+  font-size: 24px;
+  color: var(--apple-text-color-tertiary);
+}
+
+.welcome-container.is-dragover .drop-icon {
+  color: var(--apple-color-primary);
+}
+
+.drop-text {
+  font-size: 13px;
+  color: var(--apple-text-color-secondary);
+  line-height: 1.6;
+}
+
+.drop-text strong {
+  color: var(--apple-text-color-primary);
+  font-weight: 600;
+}
+
+.drop-text code {
+  background-color: var(--apple-color-gray-5);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: 'SF Mono', 'Monaco', 'Cascadia Mono', monospace;
+  font-size: 12px;
+  color: var(--apple-text-color-primary);
+}
+
+.drop-text a {
+  color: var(--apple-color-primary);
+  font-weight: 500;
+}
+
+.drop-text a:hover {
   text-decoration: underline;
 }
 
-/* 移动端样式 */
+/* Mobile */
 @media (max-width: 768px) {
-  .welcome-box {
-    padding: 24px 16px;
+  .welcome-container {
+    padding: 32px 16px;
+    align-items: flex-start;
   }
-  
-  .title {
-    font-size: 2em;
+
+  .hero-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
   }
-  
-  .subtitle {
-    font-size: 1.1em;
+
+  .hero-title {
+    font-size: 24px;
+  }
+
+  .hero-subtitle {
+    font-size: 14px;
     margin-bottom: 24px;
   }
-  
+
   .features {
-    gap: 16px;
-    margin-bottom: 24px;
+    gap: 6px;
+    margin-bottom: 28px;
   }
-  
-  .feature-item {
-    min-width: 70px;
+
+  .feature-pill {
+    font-size: 11px;
+    padding: 5px 10px;
   }
-  
-  .feature-item .el-icon {
-    font-size: 20px;
-  }
-  
-  .instructions {
-    font-size: 0.9em;
+
+  .drop-hint {
+    padding: 20px;
   }
 }
 
 @media (max-width: 480px) {
-  .welcome-container {
-    border: 1px dashed var(--el-border-color);
-    padding: 16px;
+  .hero-title {
+    font-size: 22px;
   }
-  
-  .welcome-box {
-    padding: 16px 8px;
-  }
-  
-  .title {
-    font-size: 1.8em;
-  }
-  
-  .subtitle {
-    font-size: 1em;
-  }
-  
+
   .features {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-  }
-  
-  .feature-item {
-    flex-direction: row;
-    justify-content: flex-start;
-    text-align: left;
-    min-width: auto;
-  }
-  
-  .feature-item .el-icon {
-    font-size: 18px;
-  }
-  
-  .instructions {
-    font-size: 0.85em;
+    gap: 5px;
   }
 }
 </style>

--- a/vue-frontend/src/components/common/EditorLayout.vue
+++ b/vue-frontend/src/components/common/EditorLayout.vue
@@ -23,20 +23,21 @@
   flex-direction: column;
 }
 
+/* The tabs slot already renders its own underline border via EditorTabs.
+   Keep this row as a flex container for tabs + actions only — no extra border. */
 .card-header {
-  font-size: 1.2em;
-  font-weight: 600;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
-  margin-bottom: 20px;
-  padding-bottom: 15px;
-  border-bottom: 1px solid var(--apple-border-color);
+  margin-bottom: 16px;
+  /* Bottom border is owned by EditorTabs; don't double it */
 }
 
 .header-actions {
   display: flex;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 1px; /* align baseline with tab underline */
 }
 
 .editor-content {
@@ -45,22 +46,13 @@
   overflow-x: hidden;
 }
 
-/* 移动端样式 */
 @media (max-width: 768px) {
   .editor-layout {
     padding: 0;
   }
-  
-  .card-header {
-    font-size: 1.1em;
-  }
 }
 
 @media (max-width: 480px) {
-  .card-header {
-    font-size: 1em;
-  }
-  
   .header-actions .el-button {
     font-size: 12px;
     padding: 4px 8px;

--- a/vue-frontend/src/components/ui/EditorTabs.vue
+++ b/vue-frontend/src/components/ui/EditorTabs.vue
@@ -5,14 +5,14 @@
     role="tablist"
     aria-label="Editor view switch"
   >
-    <!-- Sliding indicator -->
-    <div 
+    <!-- Sliding underline indicator -->
+    <div
       class="indicator"
       v-show="indicatorWidth > 0"
       :style="{ width: indicatorWidth + 'px', transform: `translateX(${indicatorLeft}px)` }"
       aria-hidden="true"
     />
-    <div
+    <button
       v-for="tab in tabs"
       :key="tab.value"
       class="tab"
@@ -26,7 +26,7 @@
       :data-value="tab.value"
     >
       {{ tab.label }}
-    </div>
+    </button>
   </div>
 </template>
 
@@ -43,30 +43,17 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: string): void;
 }>();
 
-// container element to measure active tab
 const containerEl = ref<HTMLElement | null>(null);
-
 const indicatorLeft = ref(0);
 const indicatorWidth = ref(0);
 
 function updateIndicator() {
   const container = containerEl.value;
-  if (!container) {
-    indicatorWidth.value = 0;
-    indicatorLeft.value = 0;
-    return;
-  }
+  if (!container) { indicatorWidth.value = 0; return; }
   const activeEl = container.querySelector(`.tab[data-value="${props.modelValue}"]`) as HTMLElement | null;
-  if (!activeEl) {
-    indicatorWidth.value = 0;
-    indicatorLeft.value = 0;
-    return;
-  }
-  // Compute left relative to container
-  const left = activeEl.offsetLeft;
-  const width = activeEl.offsetWidth;
-  indicatorLeft.value = left;
-  indicatorWidth.value = width;
+  if (!activeEl) { indicatorWidth.value = 0; return; }
+  indicatorLeft.value = activeEl.offsetLeft;
+  indicatorWidth.value = activeEl.offsetWidth;
 }
 
 onMounted(async () => {
@@ -92,84 +79,65 @@ watch(() => props.tabs, async () => {
 
 <style scoped>
 .editor-tabs {
-  --segmented-height: 34px;
-  --segmented-padding: 4px;
   display: inline-flex;
-  background: color-mix(in oklab, var(--apple-bg-color-secondary) 92%, transparent);
-  backdrop-filter: saturate(120%) blur(8px);
-  -webkit-backdrop-filter: saturate(120%) blur(8px);
-  border: 1px solid var(--apple-border-color, rgba(0,0,0,0.08));
-  border-radius: 999px;
-  overflow: hidden;
-  padding: var(--segmented-padding);
   position: relative;
-  align-items: center;
-  gap: 2px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04), inset 0 1px 0 rgba(255,255,255,0.04);
+  align-items: stretch;
+  border-bottom: 1px solid var(--apple-border-color);
+  gap: 0;
   user-select: none;
 }
 
+/* Bottom sliding underline */
 .indicator {
   position: absolute;
-  top: var(--segmented-padding);
-  bottom: var(--segmented-padding);
+  bottom: -1px;
   left: 0;
-  border-radius: 999px;
-  background: linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--apple-color-primary) 98%, white 2%),
-      color-mix(in oklab, var(--apple-color-primary) 92%, black 8%)
-    );
-  box-shadow: 0 4px 10px color-mix(in oklab, var(--apple-color-primary) 16%, black 0%), var(--apple-shadow-small);
-  transition: transform var(--apple-transition-duration, 220ms) var(--apple-transition-easing, ease), width var(--apple-transition-duration, 220ms) var(--apple-transition-easing, ease);
-  z-index: 0;
+  height: 2px;
+  border-radius: 1px;
+  background-color: var(--apple-text-color-primary);
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+              width 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1;
   pointer-events: none;
 }
 
 .tab {
-  padding: 8px 16px;
+  padding: 10px 16px;
   cursor: pointer;
-  background-color: transparent;
-  transition: color var(--apple-transition-duration, 200ms) var(--apple-transition-easing, ease), background-color var(--apple-transition-duration, 200ms) var(--apple-transition-easing, ease), transform 120ms ease;
-  border-radius: 999px;
-  position: relative;
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-size: 13px;
   font-weight: 500;
-  color: var(--apple-text-color-secondary);
-  z-index: 1; /* Above indicator */
-  line-height: calc(var(--segmented-height) - var(--segmented-padding) * 2);
-  height: calc(var(--segmented-height) - var(--segmented-padding) * 2);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 88px;
+  color: var(--apple-text-color-tertiary);
+  position: relative;
+  transition: color 150ms ease;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+  line-height: 1.5;
 }
 
 .tab:hover {
-  background-color: color-mix(in oklab, var(--apple-bg-color-tertiary) 60%, transparent);
-  color: var(--apple-text-color-primary);
+  color: var(--apple-text-color-secondary);
 }
 
 .tab.active {
-  background-color: transparent; /* use indicator as background */
-  color: var(--apple-text-color-inverse);
+  color: var(--apple-text-color-primary);
   font-weight: 600;
 }
 
-.tab:active {
-  transform: translateY(0.5px) scale(0.99);
+.tab:focus-visible {
+  outline: 2px solid var(--apple-color-primary);
+  outline-offset: -2px;
+  border-radius: 4px;
 }
 
-.tab:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px color-mix(in oklab, var(--apple-color-primary) 30%, transparent);
-  border-radius: 999px;
+.tab:active {
+  opacity: 0.75;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .indicator {
-    transition: none;
-  }
-  .tab {
     transition: none;
   }
 }

--- a/vue-frontend/src/components/ui/FormLabelWithTranslate.vue
+++ b/vue-frontend/src/components/ui/FormLabelWithTranslate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="label-with-btn">
-    <span>{{ label }}</span>
+    <span class="label-text">{{ label }}</span>
     <el-button
       v-if="showButton"
       class="translate-btn"
@@ -12,7 +12,6 @@
       {{ buttonText }}
     </el-button>
   </div>
-  
 </template>
 
 <script setup lang="ts">
@@ -35,19 +34,34 @@ withDefaults(
   width: 100%;
 }
 
+/* The label text — inherit from el-form-item__label (uppercase micro style via index.css).
+   Override font-size/weight only for the inline translate context where it may
+   be rendered outside the normal form-item label slot. */
+.label-text {
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+}
+
+/* Translate button: compact text link, no extra horizontal margin */
 .translate-btn {
-  margin-left: 10px;
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 0;
+  height: auto;
+  line-height: 1.4;
+  color: var(--el-color-primary);
+}
+
+.translate-btn:hover {
+  opacity: 0.8;
 }
 
 @media (max-width: 768px) {
   .label-with-btn {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-  }
-  .label-with-btn .translate-btn {
-    margin-left: 0;
-    align-self: flex-end;
+    flex-direction: row; /* keep inline even on mobile */
+    align-items: center;
   }
 }
 </style>

--- a/vue-frontend/src/i18n/locales/en.json
+++ b/vue-frontend/src/i18n/locales/en.json
@@ -18,6 +18,7 @@
       "json": "Export as JSON"
     },
     "actions": {
+      "title": "Actions",
       "uploadCard": "Upload Card",
       "uploadJson": "Upload JSON",
       "newBlank": "New Blank Card",

--- a/vue-frontend/src/i18n/locales/zh.json
+++ b/vue-frontend/src/i18n/locales/zh.json
@@ -18,6 +18,7 @@
       "json": "导出为JSON"
     },
     "actions": {
+      "title": "操作",
       "uploadCard": "上传卡片",
       "uploadJson": "上传JSON",
       "newBlank": "新建空白卡",

--- a/vue-frontend/src/styles/apple-theme.css
+++ b/vue-frontend/src/styles/apple-theme.css
@@ -1,112 +1,118 @@
-/* Apple 风格主题变量定义 */
+/* OpenAI-inspired design tokens */
 :root {
-  /* 主色调 - 蓝色 */
-  --apple-color-primary: #007AFF;
-  --apple-color-primary-light: #338BFF;
-  --apple-color-primary-dark: #0062CC;
-  
-  /* 成功 - 绿色 */
-  --apple-color-success: #34C759;
-  --apple-color-success-light: #5CD47D;
-  --apple-color-success-dark: #299F47;
-  
-  /* 警告 - 橙色 */
-  --apple-color-warning: #FF9500;
-  --apple-color-warning-light: #FFA933;
-  --apple-color-warning-dark: #CC7700;
-  
-  /* 危险 - 红色 */
-  --apple-color-danger: #FF3B30;
-  --apple-color-danger-light: #FF5C52;
-  --apple-color-danger-dark: #CC2F26;
-  
-  /* 中性色 */
-  --apple-color-gray-1: #8E8E93;
-  --apple-color-gray-2: #AEAEB2;
-  --apple-color-gray-3: #C7C7CC;
-  --apple-color-gray-4: #D1D1D6;
-  --apple-color-gray-5: #E5E5EA;
-  --apple-color-gray-6: #F2F2F7;
-  
-  /* 背景色 */
-  --apple-bg-color: #FFFFFF;
-  --apple-bg-color-secondary: #F2F2F7;
-  --apple-bg-color-tertiary: #FFFFFF;
-  
-  /* 文字颜色 */
-  --apple-text-color-primary: #000000;
-  --apple-text-color-secondary: #8E8E93;
-  --apple-text-color-tertiary: #C7C7CC;
-  --apple-text-color-inverse: #FFFFFF;
-  
-  /* 边框颜色 */
-  --apple-border-color: #D1D1D6;
-  --apple-border-color-secondary: #E5E5EA;
-  
-  /* 阴影 */
-  --apple-shadow-small: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --apple-shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.1);
-  --apple-shadow-large: 0 4px 16px rgba(0, 0, 0, 0.15);
-  
-  /* 圆角 */
+  /* Primary - OpenAI green accent */
+  --apple-color-primary: #10a37f;
+  --apple-color-primary-light: #1ac999;
+  --apple-color-primary-dark: #0d8a6a;
+  --apple-color-primary-alpha: rgba(16, 163, 127, 0.12);
+
+  /* Status colors */
+  --apple-color-success: #10a37f;
+  --apple-color-success-light: #1ac999;
+  --apple-color-success-dark: #0d8a6a;
+
+  --apple-color-warning: #f5a623;
+  --apple-color-warning-light: #f7b84e;
+  --apple-color-warning-dark: #d4891b;
+
+  --apple-color-danger: #ef4444;
+  --apple-color-danger-light: #f87171;
+  --apple-color-danger-dark: #dc2626;
+
+  /* Neutral grays - OpenAI palette */
+  --apple-color-gray-1: #6b7280;
+  --apple-color-gray-2: #9ca3af;
+  --apple-color-gray-3: #d1d5db;
+  --apple-color-gray-4: #e5e7eb;
+  --apple-color-gray-5: #f3f4f6;
+  --apple-color-gray-6: #f9fafb;
+
+  /* Backgrounds - clean white */
+  --apple-bg-color: #ffffff;
+  --apple-bg-color-secondary: #f7f7f8;
+  --apple-bg-color-tertiary: #ffffff;
+  --apple-bg-sidebar: #f7f7f8;
+
+  /* Text colors */
+  --apple-text-color-primary: #0d0d0d;
+  --apple-text-color-secondary: #6b7280;
+  --apple-text-color-tertiary: #9ca3af;
+  --apple-text-color-inverse: #ffffff;
+  --apple-text-color-muted: #9ca3af;
+
+  /* Borders */
+  --apple-border-color: #e5e7eb;
+  --apple-border-color-secondary: #f3f4f6;
+  --apple-border-color-strong: #d1d5db;
+
+  /* Shadows - very subtle */
+  --apple-shadow-small: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --apple-shadow-medium: 0 4px 6px -1px rgba(0, 0, 0, 0.07), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
+  --apple-shadow-large: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
+  --apple-shadow-dialog: 0 20px 60px rgba(0, 0, 0, 0.12), 0 8px 20px rgba(0, 0, 0, 0.06);
+
+  /* Border radius */
   --apple-border-radius-small: 4px;
   --apple-border-radius-medium: 8px;
   --apple-border-radius-large: 12px;
   --apple-border-radius-xl: 16px;
   --apple-border-radius-full: 9999px;
-  
-  /* 过渡效果 */
-  --apple-transition-duration: 0.2s;
-  --apple-transition-easing: cubic-bezier(0.25, 0.1, 0.25, 1);
+
+  /* Transitions */
+  --apple-transition-duration: 0.15s;
+  --apple-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 暗色主题 */
+/* Dark theme - OpenAI dark mode */
 .dark-theme {
-  /* 主色调 - 蓝色 */
-  --apple-color-primary: #0A84FF;
-  --apple-color-primary-light: #409CFF;
-  --apple-color-primary-dark: #0A6ED1;
-  
-  /* 成功 - 绿色 */
-  --apple-color-success: #30D158;
-  --apple-color-success-light: #5ACD70;
-  --apple-color-success-dark: #24A043;
-  
-  /* 警告 - 橙色 */
-  --apple-color-warning: #FF9F0A;
-  --apple-color-warning-light: #FFB340;
-  --apple-color-warning-dark: #CC7F08;
-  
-  /* 危险 - 红色 */
-  --apple-color-danger: #FF453A;
-  --apple-color-danger-light: #FF6961;
-  --apple-color-danger-dark: #CC372E;
-  
-  /* 中性色 */
-  --apple-color-gray-1: #8E8E93;
-  --apple-color-gray-2: #636366;
-  --apple-color-gray-3: #48484A;
-  --apple-color-gray-4: #3A3A3C;
-  --apple-color-gray-5: #2C2C2E;
-  --apple-color-gray-6: #1C1C1E;
-  
-  /* 背景色 */
-  --apple-bg-color: #000000;
-  --apple-bg-color-secondary: #1C1C1E;
-  --apple-bg-color-tertiary: #2C2C2E;
-  
-  /* 文字颜色 */
-  --apple-text-color-primary: #FFFFFF;
-  --apple-text-color-secondary: #98989D;
-  --apple-text-color-tertiary: #48484A;
-  --apple-text-color-inverse: #000000;
-  
-  /* 边框颜色 */
-  --apple-border-color: #3A3A3C;
-  --apple-border-color-secondary: #2C2C2E;
-  
-  /* 阴影 (暗色主题下通常不使用深色阴影) */
-  --apple-shadow-small: 0 1px 2px rgba(0, 0, 0, 0.2);
-  --apple-shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.3);
-  --apple-shadow-large: 0 4px 16px rgba(0, 0, 0, 0.4);
+  /* Primary */
+  --apple-color-primary: #19c37d;
+  --apple-color-primary-light: #2dd68f;
+  --apple-color-primary-dark: #15a86b;
+  --apple-color-primary-alpha: rgba(25, 195, 125, 0.15);
+
+  /* Status */
+  --apple-color-success: #19c37d;
+  --apple-color-success-light: #2dd68f;
+  --apple-color-success-dark: #15a86b;
+
+  --apple-color-warning: #f59e0b;
+  --apple-color-warning-light: #fbbf24;
+  --apple-color-warning-dark: #d97706;
+
+  --apple-color-danger: #f87171;
+  --apple-color-danger-light: #fca5a5;
+  --apple-color-danger-dark: #ef4444;
+
+  /* Neutral grays - OpenAI dark */
+  --apple-color-gray-1: #8e8ea0;
+  --apple-color-gray-2: #6b6b7d;
+  --apple-color-gray-3: #4a4a5a;
+  --apple-color-gray-4: #353541;
+  --apple-color-gray-5: #2d2d3a;
+  --apple-color-gray-6: #202123;
+
+  /* Backgrounds */
+  --apple-bg-color: #343541;
+  --apple-bg-color-secondary: #202123;
+  --apple-bg-color-tertiary: #444654;
+  --apple-bg-sidebar: #202123;
+
+  /* Text */
+  --apple-text-color-primary: #ececf1;
+  --apple-text-color-secondary: #8e8ea0;
+  --apple-text-color-tertiary: #6b6b7d;
+  --apple-text-color-inverse: #0d0d0d;
+  --apple-text-color-muted: #6b6b7d;
+
+  /* Borders */
+  --apple-border-color: rgba(255, 255, 255, 0.08);
+  --apple-border-color-secondary: rgba(255, 255, 255, 0.05);
+  --apple-border-color-strong: rgba(255, 255, 255, 0.12);
+
+  /* Shadows */
+  --apple-shadow-small: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --apple-shadow-medium: 0 4px 6px rgba(0, 0, 0, 0.4);
+  --apple-shadow-large: 0 10px 20px rgba(0, 0, 0, 0.5);
+  --apple-shadow-dialog: 0 20px 60px rgba(0, 0, 0, 0.6);
 }

--- a/vue-frontend/src/styles/index.css
+++ b/vue-frontend/src/styles/index.css
@@ -1,23 +1,28 @@
-/* 导入主题设置 */
+/* Import theme tokens */
 @import './theme.css';
-/* 导入 Apple 风格主题 */
 @import './apple-theme.css';
-/* 导入移动端样式 */
 @import './mobile.css';
 
-/* 全局样式 */
-* {
+/* ============================================
+   Base reset & typography
+   ============================================ */
+*, *::before, *::after {
   box-sizing: border-box;
 }
 
 body {
-  font-family: 'Segoe UI', 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', Arial, sans-serif;
+  font-family: 'Söhne', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   margin: 0;
   padding: 0;
-  background-color: var(--el-bg-color-page);
-  color: var(--el-text-color-primary);
+  background-color: var(--apple-bg-color-secondary);
+  color: var(--apple-text-color-primary);
   line-height: 1.6;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.2s ease, color 0.2s ease;
   overflow-x: hidden;
 }
 
@@ -26,27 +31,341 @@ body {
   overflow-x: hidden;
 }
 
+/* ============================================
+   Scrollbars - minimal OpenAI style
+   ============================================ */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--apple-color-gray-3);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--apple-color-gray-2);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--apple-color-gray-3) transparent;
+}
+
+/* ============================================
+   Text selection
+   ============================================ */
+::selection {
+  background-color: var(--apple-color-primary-alpha);
+  color: var(--apple-text-color-primary);
+}
+
+/* ============================================
+   Focus
+   ============================================ */
+:focus-visible {
+  outline: 2px solid var(--apple-color-primary);
+  outline-offset: 2px;
+  border-radius: var(--apple-border-radius-small);
+}
+
+/* ============================================
+   Links
+   ============================================ */
+a {
+  color: var(--apple-color-primary);
+  text-decoration: none;
+  transition: color var(--apple-transition-duration) var(--apple-transition-easing);
+}
+
+a:hover {
+  color: var(--apple-color-primary-dark);
+}
+
+/* ============================================
+   Element Plus - Button overrides
+   ============================================ */
+.el-button {
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 13px;
+  border-radius: var(--apple-border-radius-medium);
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
+  letter-spacing: 0.01em;
+}
+
+.el-button--primary {
+  background-color: var(--apple-color-primary);
+  border-color: var(--apple-color-primary);
+  color: #ffffff;
+}
+
+.el-button--primary:hover,
+.el-button--primary:focus {
+  background-color: var(--apple-color-primary-dark);
+  border-color: var(--apple-color-primary-dark);
+  color: #ffffff;
+  opacity: 1;
+}
+
+.el-button--default {
+  background-color: var(--el-bg-color);
+  border-color: var(--el-border-color);
+  color: var(--el-text-color-primary);
+}
+
+.el-button--default:hover {
+  background-color: var(--el-fill-color-light);
+  border-color: var(--el-border-color-dark);
+  color: var(--el-text-color-primary);
+}
+
+/* ============================================
+   Element Plus - Input overrides
+   ============================================ */
+.el-input__wrapper {
+  border-radius: var(--apple-border-radius-medium);
+  box-shadow: 0 0 0 1px var(--el-border-color) inset;
+  transition: box-shadow var(--apple-transition-duration) var(--apple-transition-easing);
+  background-color: var(--el-bg-color);
+}
+
+.el-input__wrapper:hover {
+  box-shadow: 0 0 0 1px var(--el-border-color-dark) inset;
+}
+
+.el-input__wrapper.is-focus {
+  box-shadow: 0 0 0 1.5px var(--apple-color-primary) inset !important;
+}
+
+.el-input__inner {
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+
+.el-input__inner::placeholder {
+  color: var(--el-text-color-placeholder);
+}
+
+.el-textarea__inner {
+  font-family: inherit;
+  font-size: 13px;
+  border-radius: var(--apple-border-radius-medium);
+  box-shadow: 0 0 0 1px var(--el-border-color) inset;
+  background-color: var(--el-bg-color);
+  color: var(--el-text-color-primary);
+  line-height: 1.65;
+  transition: box-shadow var(--apple-transition-duration) var(--apple-transition-easing);
+  resize: vertical;
+}
+
+.el-textarea__inner:hover {
+  box-shadow: 0 0 0 1px var(--el-border-color-dark) inset;
+}
+
+.el-textarea__inner:focus {
+  box-shadow: 0 0 0 1.5px var(--apple-color-primary) inset !important;
+  outline: none;
+}
+
+.el-textarea__inner::placeholder {
+  color: var(--el-text-color-placeholder);
+}
+
+/* ============================================
+   Element Plus - Form overrides
+   ============================================ */
+.el-form-item {
+  margin-bottom: 18px;
+}
+
+.el-form-item__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--el-text-color-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding-bottom: 6px;
+  line-height: 1.5;
+}
+
+/* ============================================
+   Element Plus - Card overrides
+   ============================================ */
+.el-card {
+  border-radius: var(--apple-border-radius-large);
+  border: 1px solid var(--el-border-color);
+  background-color: var(--el-bg-color);
+  box-shadow: var(--apple-shadow-small);
+  transition: box-shadow var(--apple-transition-duration) var(--apple-transition-easing);
+  margin-bottom: 16px;
+}
+
+.el-card:hover {
+  box-shadow: var(--apple-shadow-medium);
+}
+
+.el-card__header {
+  border-bottom: 1px solid var(--el-border-color);
+  padding: 16px 20px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--el-text-color-primary);
+  background-color: transparent;
+}
+
+.el-card__body {
+  padding: 20px;
+}
+
+/* ============================================
+   Element Plus - Dialog overrides
+   ============================================ */
+.el-dialog {
+  border-radius: var(--apple-border-radius-xl);
+  background-color: var(--el-bg-color);
+  border: 1px solid var(--el-border-color);
+  box-shadow: var(--apple-shadow-dialog);
+  overflow: hidden;
+}
+
+.el-dialog__header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--el-border-color);
+  margin: 0;
+}
+
+.el-dialog__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--el-text-color-primary);
+  letter-spacing: -0.01em;
+}
+
+.el-dialog__body {
+  padding: 24px;
+  color: var(--el-text-color-primary);
+}
+
+.el-dialog__footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--el-border-color);
+  text-align: right;
+}
+
+.el-dialog__headerbtn {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--apple-border-radius-medium);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--apple-transition-duration) var(--apple-transition-easing);
+}
+
+.el-dialog__headerbtn:hover {
+  background-color: var(--el-fill-color);
+}
+
+/* ============================================
+   Element Plus - Tag overrides
+   ============================================ */
+.el-tag {
+  border-radius: var(--apple-border-radius-small);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  height: 22px;
+  letter-spacing: 0.02em;
+}
+
+/* ============================================
+   Element Plus - Collapse overrides
+   ============================================ */
+.el-collapse {
+  border: 1px solid var(--el-border-color);
+  border-radius: var(--apple-border-radius-large);
+  overflow: hidden;
+}
+
+.el-collapse-item__header {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 12px 16px;
+  color: var(--el-text-color-primary);
+  background-color: var(--el-fill-color-lighter);
+}
+
+.el-collapse-item__content {
+  padding: 16px;
+  font-size: 13px;
+}
+
+.el-collapse-item__wrap {
+  border-bottom: 1px solid var(--el-border-color);
+}
+
+/* ============================================
+   Element Plus - Alert overrides
+   ============================================ */
+.el-alert {
+  border-radius: var(--apple-border-radius-medium);
+  border: 1px solid var(--el-border-color);
+  padding: 10px 14px;
+  font-size: 13px;
+}
+
+/* ============================================
+   Element Plus - Radio overrides
+   ============================================ */
+.el-radio-group {
+  gap: 8px;
+}
+
+.el-radio {
+  font-size: 13px;
+  color: var(--el-text-color-primary);
+}
+
+.el-radio__inner {
+  border-color: var(--el-border-color-dark);
+  transition: all var(--apple-transition-duration) var(--apple-transition-easing);
+}
+
+/* ============================================
+   Element Plus - Message/Notification
+   ============================================ */
+.el-message {
+  border-radius: var(--apple-border-radius-large);
+  border: 1px solid var(--el-border-color);
+  box-shadow: var(--apple-shadow-large);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+/* ============================================
+   Utility classes
+   ============================================ */
 .container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0;
 }
 
-.steps-container {
-  padding: 0 20px;
-  max-width: 1000px;
-  margin: 0 auto;
-}
-
-/* 动画效果 */
 .fade-in {
-  animation: fadeIn 0.6s ease-in-out;
+  animation: fadeIn 0.3s ease-out;
 }
 
 @keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(8px);
   }
   to {
     opacity: 1;
@@ -54,330 +373,6 @@ body {
   }
 }
 
-/* 卡片样式 */
-.el-card {
-  margin-bottom: 30px;
-  border-radius: 12px;
-  border: 1px solid var(--el-border-color-light);
-  background-color: var(--el-bg-color);
-  box-shadow: var(--el-box-shadow-lighter);
-  transition: var(--el-transition-duration);
-}
-
-.el-card:hover {
-  box-shadow: var(--el-box-shadow-light);
-}
-
-.el-card__header {
-  background-color: var(--el-fill-color-light);
-  border-bottom: 1px solid var(--el-border-color-light);
-  border-radius: 12px 12px 0 0;
-  padding: 20px;
-}
-
-.el-card__body {
-  padding: 30px;
-}
-
-/* 按钮样式 */
-.el-button {
-  border-radius: 8px;
-  font-weight: 500;
-  transition: var(--el-transition-duration);
-}
-
-.el-button--primary {
-  background-color: var(--el-color-primary);
-  border-color: var(--el-color-primary);
-}
-
-.el-button--primary:hover {
-  background-color: var(--el-color-primary-dark-2);
-  border-color: var(--el-color-primary-dark-2);
-}
-
-/* 输入框样式 */
-.el-input__wrapper {
-  border-radius: 8px;
-  transition: var(--el-transition-duration);
-}
-
-.el-input__inner {
-  font-size: 14px;
-}
-
-/* 上传组件样式 */
-.el-upload-dragger {
-  border-radius: 12px;
-  border: 2px dashed var(--el-border-color-light);
-  background-color: var(--el-fill-color-light);
-  transition: var(--el-transition-duration);
-}
-
-.el-upload-dragger:hover {
-  border-color: var(--el-color-primary);
-  background-color: var(--el-fill-color);
-}
-
-/* 步骤条样式 */
-.el-steps {
-  margin-bottom: 30px;
-}
-
-.el-step__title {
-  font-weight: 600;
-  color: var(--el-text-color-primary);
-}
-
-.el-step__main {
-  margin-left: 12px;
-}
-
-/* 标签样式 */
-.el-tag {
-  border-radius: 20px;
-  font-size: 12px;
-  padding: 4px 12px;
-  transition: var(--el-transition-duration);
-}
-
-.el-tag:hover {
-  cursor: pointer;
-  opacity: 0.8;
-}
-
-/* 进度条样式 */
-.el-progress-bar__outer {
-  border-radius: 10px;
-  background-color: var(--el-fill-color-light);
-}
-
-.el-progress-bar__inner {
-  border-radius: 10px;
-  transition: width 0.6s ease;
-}
-
-/* 对话框样式 */
-.el-dialog {
-  border-radius: 12px;
-  background-color: var(--el-bg-color);
-}
-
-.el-dialog__header {
-  padding: 20px 20px 10px;
-  border-bottom: 1px solid var(--el-border-color-light);
-}
-
-.el-dialog__body {
-  padding: 20px;
-  color: var(--el-text-color-primary);
-}
-
-.el-dialog__footer {
-  padding: 15px 20px 20px;
-  text-align: right;
-}
-
-/* 警告框样式 */
-.el-alert {
-  border-radius: 8px;
-  border: 1px solid var(--el-border-color-light);
-}
-
-/* 响应式设计 */
-@media (max-width: 768px) {
-  .steps-container {
-    padding: 0 16px;
-  }
-  
-  .el-card {
-    margin-bottom: 20px;
-    border-radius: 8px;
-  }
-  
-  .el-card__header {
-    padding: 16px;
-  }
-  
-  .el-card__body {
-    padding: 16px;
-  }
-  
-  .container {
-    padding: 0 16px;
-  }
-  
-  .el-button {
-    font-size: 14px;
-    padding: 8px 16px;
-    min-height: 36px;
-  }
-  
-  .el-input__inner {
-    font-size: 14px;
-    min-height: 36px;
-  }
-  
-  .el-form-item {
-    margin-bottom: 16px;
-  }
-  
-  .el-form-item__label {
-    font-size: 14px;
-    margin-bottom: 6px;
-    min-height: 20px;
-    display: flex;
-    align-items: center;
-  }
-  
-  .el-textarea__inner {
-    font-size: 14px;
-    min-height: 36px;
-  }
-  
-  .el-steps {
-    margin-bottom: 20px;
-  }
-  
-  .el-step__title {
-    font-size: 14px;
-  }
-  
-  .el-step__description {
-    font-size: 12px;
-  }
-  
-  .el-dialog {
-    margin: 5vh auto 0;
-    width: 95% !important;
-  }
-  
-  /* 移动端表单优化 */
-  .el-form--label-top .el-form-item__label {
-    padding: 0 0 6px 0;
-  }
-  
-  .el-row {
-    margin-left: -8px;
-    margin-right: -8px;
-  }
-  
-  .el-col {
-    padding-left: 8px;
-    padding-right: 8px;
-  }
-}
-
-@media (max-width: 480px) {
-  .container {
-    padding: 0 12px;
-  }
-  
-  .steps-container {
-    padding: 0 12px;
-  }
-  
-  .el-card {
-    margin-bottom: 16px;
-    border-radius: 6px;
-  }
-  
-  .el-card__header {
-    padding: 12px;
-  }
-  
-  .el-card__body {
-    padding: 12px;
-  }
-  
-  .el-form-item__label {
-    font-size: 13px;
-    margin-bottom: 4px;
-  }
-  
-  .el-input__inner {
-    font-size: 13px;
-  }
-  
-  .el-button {
-    font-size: 13px;
-    padding: 6px 12px;
-  }
-  
-  .el-textarea__inner {
-    font-size: 13px;
-  }
-  
-  .el-form-item {
-    margin-bottom: 12px;
-  }
-  
-  .el-row {
-    margin-left: -4px;
-    margin-right: -4px;
-  }
-  
-  .el-col {
-    padding-left: 4px;
-    padding-right: 4px;
-  }
-}
-
-/* 滚动条样式 */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--el-fill-color-light);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--el-border-color-light);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--el-text-color-secondary);
-}
-
-/* Firefox 滚动条 */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--el-border-color-light) var(--el-fill-color-light);
-}
-
-/* 选择文本样式 */
-::selection {
-  background-color: var(--el-color-primary);
-  color: white;
-}
-
-::-moz-selection {
-  background-color: var(--el-color-primary);
-  color: white;
-}
-
-/* 焦点样式 */
-:focus-visible {
-  outline: 2px solid var(--el-color-primary);
-  outline-offset: 2px;
-}
-
-/* 链接样式 */
-a {
-  color: var(--el-color-primary);
-  text-decoration: none;
-  transition: var(--el-transition-duration);
-}
-
-a:hover {
-  color: var(--el-color-primary-dark-2);
-}
-
-/* 加载动画 */
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
@@ -387,12 +382,14 @@ a:hover {
   animation: spin 1s linear infinite;
 }
 
-/* 防止水平滚动的样式 */
-.el-form {
-  width: 100%;
-}
-
-.el-form-item {
+/* ============================================
+   Prevent horizontal overflow
+   ============================================ */
+.el-form,
+.el-form-item,
+.el-input,
+.el-textarea {
+  max-width: 100%;
   width: 100%;
 }
 
@@ -407,12 +404,57 @@ a:hover {
   padding-right: 0 !important;
 }
 
-.el-input,
-.el-textarea {
-  max-width: 100%;
-}
-
 .el-textarea__inner,
 .el-input__inner {
   max-width: 100%;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+@media (max-width: 768px) {
+  .el-card {
+    border-radius: var(--apple-border-radius-medium);
+  }
+
+  .el-card__header {
+    padding: 12px 16px;
+  }
+
+  .el-card__body {
+    padding: 16px;
+  }
+
+  .el-button {
+    font-size: 13px;
+    padding: 8px 14px;
+  }
+
+  .el-form-item {
+    margin-bottom: 14px;
+  }
+
+  .el-dialog {
+    margin: 5vh auto 0;
+    width: 95% !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .el-card__header {
+    padding: 10px 12px;
+  }
+
+  .el-card__body {
+    padding: 12px;
+  }
+
+  .el-button {
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+
+  .el-form-item {
+    margin-bottom: 12px;
+  }
 }

--- a/vue-frontend/src/styles/theme.css
+++ b/vue-frontend/src/styles/theme.css
@@ -1,189 +1,188 @@
-/* Element Plus 主题变量定义 */
+/* Element Plus theme - OpenAI inspired */
 :root {
-  /* 使用 Element Plus 官方颜色变量 */
-  --el-color-primary: #409eff;
-  --el-color-primary-light-3: #79bbff;
-  --el-color-primary-light-5: #a0cfff;
-  --el-color-primary-light-7: #c6e2ff;
-  --el-color-primary-light-8: #d9ecff;
-  --el-color-primary-light-9: #ecf5ff;
-  --el-color-primary-dark-2: #337ecc;
-  
-  --el-color-success: #67c23a;
-  --el-color-success-light-3: #95d475;
-  --el-color-success-light-5: #b3e19d;
-  --el-color-success-light-7: #d1edc4;
-  --el-color-success-light-8: #e1f3d8;
-  --el-color-success-light-9: #f0f9eb;
-  
-  --el-color-warning: #e6a23c;
-  --el-color-warning-light-3: #eebe77;
-  --el-color-warning-light-5: #f3d19e;
-  --el-color-warning-light-7: #f8e3c5;
-  --el-color-warning-light-8: #faecd8;
-  --el-color-warning-light-9: #fdf6ec;
-  
-  --el-color-danger: #f56c6c;
-  --el-color-danger-light-3: #f89898;
-  --el-color-danger-light-5: #fab6b6;
-  --el-color-danger-light-7: #fcd3d3;
-  --el-color-danger-light-8: #fde2e2;
+  /* Primary - OpenAI green */
+  --el-color-primary: #10a37f;
+  --el-color-primary-light-3: #3db89a;
+  --el-color-primary-light-5: #6ccab5;
+  --el-color-primary-light-7: #9addd0;
+  --el-color-primary-light-8: #b2e6dc;
+  --el-color-primary-light-9: #d9f3ee;
+  --el-color-primary-dark-2: #0d8a6a;
+
+  --el-color-success: #10a37f;
+  --el-color-success-light-3: #3db89a;
+  --el-color-success-light-5: #6ccab5;
+  --el-color-success-light-7: #9addd0;
+  --el-color-success-light-8: #b2e6dc;
+  --el-color-success-light-9: #d9f3ee;
+
+  --el-color-warning: #f5a623;
+  --el-color-warning-light-3: #f7b84e;
+  --el-color-warning-light-5: #f9c97a;
+  --el-color-warning-light-7: #fbdaa5;
+  --el-color-warning-light-8: #fce3bb;
+  --el-color-warning-light-9: #fef3e2;
+
+  --el-color-danger: #ef4444;
+  --el-color-danger-light-3: #f47070;
+  --el-color-danger-light-5: #f89898;
+  --el-color-danger-light-7: #fbc0c0;
+  --el-color-danger-light-8: #fdd0d0;
   --el-color-danger-light-9: #fef0f0;
-  
-  --el-color-info: #909399;
-  --el-color-info-light-3: #b1b3b8;
-  --el-color-info-light-5: #c8c9cc;
-  --el-color-info-light-7: #dedfe0;
-  --el-color-info-light-8: #e9e9eb;
-  --el-color-info-light-9: #f4f4f5;
 
-  /* 背景色 */
+  --el-color-info: #6b7280;
+  --el-color-info-light-3: #9ca3af;
+  --el-color-info-light-5: #b5bcc7;
+  --el-color-info-light-7: #ced3db;
+  --el-color-info-light-8: #dde0e5;
+  --el-color-info-light-9: #f3f4f6;
+
+  /* Backgrounds */
   --el-bg-color: #ffffff;
-  --el-bg-color-page: #f2f3f5;
+  --el-bg-color-page: #f7f7f8;
   --el-bg-color-overlay: #ffffff;
-  
-  /* 文字颜色 */
-  --el-text-color-primary: #303133;
-  --el-text-color-regular: #606266;
-  --el-text-color-secondary: #909399;
-  --el-text-color-placeholder: #a8abb2;
-  --el-text-color-disabled: #c0c4cc;
-  
-  /* 边框颜色 */
-  --el-border-color: #dcdfe6;
-  --el-border-color-light: #e4e7ed;
-  --el-border-color-lighter: #ebeef5;
-  --el-border-color-extra-light: #f2f6fc;
-  --el-border-color-dark: #d4d7de;
-  --el-border-color-darker: #cdd0d6;
-  
-  /* 填充色 */
-  --el-fill-color: #f0f2f5;
-  --el-fill-color-light: #f5f7fa;
+
+  /* Text */
+  --el-text-color-primary: #0d0d0d;
+  --el-text-color-regular: #374151;
+  --el-text-color-secondary: #6b7280;
+  --el-text-color-placeholder: #9ca3af;
+  --el-text-color-disabled: #d1d5db;
+
+  /* Borders */
+  --el-border-color: #e5e7eb;
+  --el-border-color-light: #f3f4f6;
+  --el-border-color-lighter: #f9fafb;
+  --el-border-color-extra-light: #fafafa;
+  --el-border-color-dark: #d1d5db;
+  --el-border-color-darker: #9ca3af;
+
+  /* Fill */
+  --el-fill-color: #f3f4f6;
+  --el-fill-color-light: #f9fafb;
   --el-fill-color-lighter: #fafafa;
-  --el-fill-color-extra-light: #fafcff;
-  --el-fill-color-dark: #ebedf0;
-  --el-fill-color-darker: #e6e8eb;
+  --el-fill-color-extra-light: #fdfdfd;
+  --el-fill-color-dark: #e5e7eb;
+  --el-fill-color-darker: #d1d5db;
   --el-fill-color-blank: #ffffff;
-  
-  /* 阴影 */
-  --el-box-shadow: 0px 12px 32px 4px rgba(0, 0, 0, 0.04), 0px 8px 20px rgba(0, 0, 0, 0.08);
-  --el-box-shadow-light: 0px 0px 12px rgba(0, 0, 0, 0.12);
-  --el-box-shadow-lighter: 0px 0px 6px rgba(0, 0, 0, 0.12);
-  --el-box-shadow-dark: 0px 16px 48px 16px rgba(0, 0, 0, 0.08), 0px 12px 32px rgba(0, 0, 0, 0.12), 0px 8px 16px -8px rgba(0, 0, 0, 0.16);
-  
-  /* 禁用状态 */
+
+  /* Shadows */
+  --el-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.07), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
+  --el-box-shadow-light: 0 2px 4px rgba(0, 0, 0, 0.06);
+  --el-box-shadow-lighter: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --el-box-shadow-dark: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+  /* Disabled */
   --el-disabled-bg-color: var(--el-fill-color-light);
   --el-disabled-text-color: var(--el-text-color-placeholder);
   --el-disabled-border-color: var(--el-border-color-light);
-  
-  /* 自定义项目变量 */
+
+  /* Custom project vars */
   --header-text: #ffffff;
-  --header-divider: rgba(255, 255, 255, 0.8);
-  --gradient-primary: linear-gradient(135deg, #409eff, #0ea5e9, #0d9488);
-  
-  /* 过渡效果 */
-  --el-transition-duration: 0.3s;
-  --el-transition-duration-fast: 0.2s;
+  --header-divider: rgba(255, 255, 255, 0.6);
+  --gradient-primary: linear-gradient(135deg, #10a37f, #0d8a6a);
+
+  /* Transitions */
+  --el-transition-duration: 0.15s;
+  --el-transition-duration-fast: 0.1s;
 }
 
-/* 暗色主题 */
+/* Dark theme */
 .dark-theme {
-  /* Element Plus 暗色主题变量 */
-  --el-color-primary: #409eff;
-  --el-color-primary-light-3: #3375b9;
-  --el-color-primary-light-5: #2a598a;
-  --el-color-primary-light-7: #213d5c;
-  --el-color-primary-light-8: #1d3043;
-  --el-color-primary-light-9: #18222c;
-  --el-color-primary-dark-2: #66b1ff;
-  
-  --el-color-success: #67c23a;
-  --el-color-success-light-3: #529b2e;
-  --el-color-success-light-5: #437424;
-  --el-color-success-light-7: #344e1a;
-  --el-color-success-light-8: #2b4016;
-  --el-color-success-light-9: #233312;
-  
-  --el-color-warning: #e6a23c;
-  --el-color-warning-light-3: #b88230;
-  --el-color-warning-light-5: #946827;
-  --el-color-warning-light-7: #714e1e;
-  --el-color-warning-light-8: #5d4119;
-  --el-color-warning-light-9: #4a3515;
-  
-  --el-color-danger: #f56c6c;
-  --el-color-danger-light-3: #c45656;
-  --el-color-danger-light-5: #a04747;
-  --el-color-danger-light-7: #7c3838;
-  --el-color-danger-light-8: #672f2f;
-  --el-color-danger-light-9: #532525;
-  
-  --el-color-info: #909399;
-  --el-color-info-light-3: #73767a;
-  --el-color-info-light-5: #5e6064;
-  --el-color-info-light-7: #494a4e;
-  --el-color-info-light-8: #3c3d40;
-  --el-color-info-light-9: #303133;
+  --el-color-primary: #19c37d;
+  --el-color-primary-light-3: #0f7a4e;
+  --el-color-primary-light-5: #0a5c3b;
+  --el-color-primary-light-7: #083d27;
+  --el-color-primary-light-8: #062d1e;
+  --el-color-primary-light-9: #041e14;
+  --el-color-primary-dark-2: #2dd68f;
 
-  /* 背景色 - 暗色主题 */
-  --el-bg-color: #141414;
-  --el-bg-color-page: #0a0a0a;
-  --el-bg-color-overlay: #1d1e1f;
-  
-  /* 文字颜色 - 暗色主题 */
-  --el-text-color-primary: #e5eaf3;
-  --el-text-color-regular: #cfd3dc;
-  --el-text-color-secondary: #a3a6ad;
-  --el-text-color-placeholder: #8d9095;
-  --el-text-color-disabled: #6c6e72;
-  
-  /* 边框颜色 - 暗色主题 */
-  --el-border-color: #4c4d4f;
-  --el-border-color-light: #414243;
-  --el-border-color-lighter: #363637;
-  --el-border-color-extra-light: #2b2b2c;
-  --el-border-color-dark: #58585b;
-  --el-border-color-darker: #636466;
-  
-  /* 填充色 - 暗色主题 */
-  --el-fill-color: #2b2b2c;
-  --el-fill-color-light: #262727;
-  --el-fill-color-lighter: #1f2021;
-  --el-fill-color-extra-light: #191a1b;
-  --el-fill-color-dark: #303133;
-  --el-fill-color-darker: #36383a;
-  --el-fill-color-blank: #141414;
-  
-  /* 阴影 - 暗色主题 */
-  --el-box-shadow: 0px 12px 32px 4px rgba(0, 0, 0, 0.36), 0px 8px 20px rgba(0, 0, 0, 0.72);
-  --el-box-shadow-light: 0px 0px 12px rgba(0, 0, 0, 0.72);
-  --el-box-shadow-lighter: 0px 0px 6px rgba(0, 0, 0, 0.72);
-  --el-box-shadow-dark: 0px 16px 48px 16px rgba(0, 0, 0, 0.72), 0px 12px 32px rgba(0, 0, 0, 0.84), 0px 8px 16px -8px rgba(0, 0, 0, 0.9);
-  
-  /* 禁用状态 - 暗色主题 */
+  --el-color-success: #19c37d;
+  --el-color-success-light-3: #0f7a4e;
+  --el-color-success-light-5: #0a5c3b;
+  --el-color-success-light-7: #083d27;
+  --el-color-success-light-8: #062d1e;
+  --el-color-success-light-9: #041e14;
+
+  --el-color-warning: #f59e0b;
+  --el-color-warning-light-3: #926008;
+  --el-color-warning-light-5: #6e4806;
+  --el-color-warning-light-7: #4a3005;
+  --el-color-warning-light-8: #362404;
+  --el-color-warning-light-9: #221803;
+
+  --el-color-danger: #f87171;
+  --el-color-danger-light-3: #9b2626;
+  --el-color-danger-light-5: #7a1e1e;
+  --el-color-danger-light-7: #591515;
+  --el-color-danger-light-8: #451010;
+  --el-color-danger-light-9: #310b0b;
+
+  --el-color-info: #8e8ea0;
+  --el-color-info-light-3: #5a5a6e;
+  --el-color-info-light-5: #47475a;
+  --el-color-info-light-7: #353547;
+  --el-color-info-light-8: #2a2a3a;
+  --el-color-info-light-9: #1e1e2e;
+
+  /* Backgrounds */
+  --el-bg-color: #343541;
+  --el-bg-color-page: #202123;
+  --el-bg-color-overlay: #40414f;
+
+  /* Text */
+  --el-text-color-primary: #ececf1;
+  --el-text-color-regular: #d1d5db;
+  --el-text-color-secondary: #8e8ea0;
+  --el-text-color-placeholder: #6b6b7d;
+  --el-text-color-disabled: #4a4a5a;
+
+  /* Borders */
+  --el-border-color: rgba(255, 255, 255, 0.1);
+  --el-border-color-light: rgba(255, 255, 255, 0.07);
+  --el-border-color-lighter: rgba(255, 255, 255, 0.05);
+  --el-border-color-extra-light: rgba(255, 255, 255, 0.03);
+  --el-border-color-dark: rgba(255, 255, 255, 0.15);
+  --el-border-color-darker: rgba(255, 255, 255, 0.2);
+
+  /* Fill */
+  --el-fill-color: #40414f;
+  --el-fill-color-light: #3c3d4a;
+  --el-fill-color-lighter: #383948;
+  --el-fill-color-extra-light: #343541;
+  --el-fill-color-dark: #444554;
+  --el-fill-color-darker: #4a4b5a;
+  --el-fill-color-blank: #343541;
+
+  /* Shadows */
+  --el-box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --el-box-shadow-light: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --el-box-shadow-lighter: 0 1px 4px rgba(0, 0, 0, 0.25);
+  --el-box-shadow-dark: 0 10px 25px rgba(0, 0, 0, 0.6);
+
+  /* Disabled */
   --el-disabled-bg-color: var(--el-fill-color-light);
   --el-disabled-text-color: var(--el-text-color-placeholder);
   --el-disabled-border-color: var(--el-border-color-light);
-  
-  /* 自定义项目变量 - 暗色主题 */
-  --header-text: #ffffff;
-  --header-divider: rgba(255, 255, 255, 0.8);
-  --gradient-primary: linear-gradient(135deg, #1e3a8a, #0c4a6e, #134e4a);
+
+  /* Custom */
+  --header-text: #ececf1;
+  --header-divider: rgba(255, 255, 255, 0.15);
+  --gradient-primary: linear-gradient(135deg, #19c37d, #0f7a4e);
 }
 
-/* 主题切换过渡效果 */
+/* Theme transition */
 .theme-transition,
 .theme-transition *,
 .theme-transition *:before,
 .theme-transition *:after {
-  transition: all 300ms !important;
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease !important;
   transition-delay: 0 !important;
 }
 
-/* Element Plus 暗色主题下按钮样式补充 */
+/* Dark theme button overrides */
 .dark-theme .el-button--primary.is-text {
-  color: var(--el-color-primary-light-3);
+  color: var(--el-color-primary);
   background-color: transparent;
   border-color: transparent;
 }
@@ -200,13 +199,13 @@
 }
 
 .dark-theme .el-button--primary.is-plain:hover {
-  color: var(--el-bg-color);
+  color: #ffffff;
   background-color: var(--el-color-primary);
   border-color: var(--el-color-primary);
 }
 
 .dark-theme .el-button--danger.is-text {
-  color: var(--el-color-danger-light-3);
+  color: var(--el-color-danger);
   background-color: transparent;
   border-color: transparent;
 }
@@ -228,7 +227,6 @@
   border-color: var(--el-color-primary);
 }
 
-/* 圆形按钮样式 */
 .dark-theme .el-button.is-circle {
   background-color: var(--el-fill-color);
   border-color: var(--el-border-color);
@@ -238,10 +236,10 @@
 .dark-theme .el-button--danger.is-circle {
   background-color: var(--el-color-danger);
   border-color: var(--el-color-danger);
-  color: var(--el-bg-color);
+  color: #ffffff;
 }
 
 .dark-theme .el-button--danger.is-circle:hover {
-  background-color: var(--el-color-danger-light-3);
-  border-color: var(--el-color-danger-light-3);
+  background-color: var(--el-color-danger-dark-2);
+  border-color: var(--el-color-danger-dark-2);
 }


### PR DESCRIPTION
- Replace Apple blue (#007AFF) design tokens with OpenAI green (#10a37f)
- Adopt neutral gray palette (Tailwind-inspired) for both light and dark themes
- Rewrite apple-theme.css, theme.css, index.css with new design tokens
- AppSidebar: ChatGPT-style action list, flexible width (fit-content 220-280px) to prevent overflow when switching to English locale
- EditorTabs: underline indicator replaces old pill/slider animation
- WelcomeView: modern hero layout with feature pills and dashed drop zone
- ThemeToggle & LanguageSwitcher: compact 32px button style for sidebar footer
- TranslationSettingsDialog: flat dialog with uppercase micro-labels
- CharacterEditor & CharacterBookEditor: flat entry cards, remove stale 220ms animation delay (no longer needed with underline tabs)
- EditorLayout: remove duplicate border-bottom (now owned by EditorTabs)
- FormLabelWithTranslate: compact inline translate link style
- i18n: add sidebar.actions.title key to zh/en locales